### PR TITLE
Add ancillary data download functionality

### DIFF
--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -4,12 +4,7 @@ import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
-from typing import (
-    Iterator,
-    List,
-    Tuple,
-    Union
-)
+from typing import Iterator, List, Tuple, Union
 
 import pandas as pd
 import requests

--- a/src/hyp3_isce2/process.py
+++ b/src/hyp3_isce2/process.py
@@ -55,7 +55,7 @@ def topsapp_burst(
 
     download_aux_cal(aux_cal_dir)
     for granule in (ref_params.granule, sec_params.granule):
-        orbit_file, _ = downloadSentinelOrbitFile(granule, orbit_dir)
+        downloadSentinelOrbitFile(granule, orbit_dir)
 
     # TODO replace with the actual processing call once we have the functionality for downloading the input data
     subprocess.run(['python', TOPSAPP, '-h'])

--- a/src/hyp3_isce2/process.py
+++ b/src/hyp3_isce2/process.py
@@ -5,12 +5,21 @@ ISCE2 processing
 import logging
 import os
 import subprocess
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from argparse import (
+    ArgumentDefaultsHelpFormatter,
+    ArgumentParser
+)
 from pathlib import Path
 
+from hyp3lib.get_orb import downloadSentinelOrbitFile
+
 from hyp3_isce2 import __version__
-from hyp3_isce2.burst import (BurstParams, download_bursts,
-                              get_region_of_interest)
+from hyp3_isce2.burst import (
+    BurstParams,
+    download_bursts,
+    get_region_of_interest
+)
+
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +48,7 @@ def topsapp_burst(
         azimuth_looks: Number of azimuth looks
         range_looks: Number of range looks
     """
+    orbit_dir = 'orbits'
     ref_params = BurstParams(reference_scene, f'IW{swath_number}', polarization.upper(), reference_burst_number)
     sec_params = BurstParams(secondary_scene, f'IW{swath_number}', polarization.upper(), secondary_burst_number)
     ref_metadata, sec_metadata = download_bursts([ref_params, sec_params])
@@ -47,6 +57,9 @@ def topsapp_burst(
     insar_roi = get_region_of_interest(ref_metadata.footprint, sec_metadata.footprint, is_ascending=is_ascending)
     dem_roi = ref_metadata.footprint.intersection(sec_metadata.footprint).bounds
     print(insar_roi, dem_roi)
+
+    for granule in (ref_params.granule, sec_params.granule):
+        orbit_file, _ = downloadSentinelOrbitFile(granule, orbit_dir)
     # TODO replace with the actual processing call once we have the functionality for downloading the input data
     subprocess.run(['python', TOPSAPP, '-h'])
 

--- a/src/hyp3_isce2/process.py
+++ b/src/hyp3_isce2/process.py
@@ -59,7 +59,7 @@ def topsapp_burst(
     insar_roi = get_region_of_interest(ref_metadata.footprint, sec_metadata.footprint, is_ascending=is_ascending)
     dem_roi = ref_metadata.footprint.intersection(sec_metadata.footprint).bounds
     print(insar_roi, dem_roi)
-    
+
     download_aux_cal(aux_cal_dir)
     for granule in (ref_params.granule, sec_params.granule):
         orbit_file, _ = downloadSentinelOrbitFile(granule, orbit_dir)

--- a/src/hyp3_isce2/process.py
+++ b/src/hyp3_isce2/process.py
@@ -5,20 +5,13 @@ ISCE2 processing
 import logging
 import os
 import subprocess
-from argparse import (
-    ArgumentDefaultsHelpFormatter,
-    ArgumentParser
-)
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 
 from hyp3lib.get_orb import downloadSentinelOrbitFile
 
 from hyp3_isce2 import __version__
-from hyp3_isce2.burst import (
-    BurstParams,
-    download_bursts,
-    get_region_of_interest
-)
+from hyp3_isce2.burst import BurstParams, download_bursts, get_region_of_interest
 from hyp3_isce2.s1_auxcal import download_aux_cal
 
 

--- a/src/hyp3_isce2/process.py
+++ b/src/hyp3_isce2/process.py
@@ -19,6 +19,7 @@ from hyp3_isce2.burst import (
     download_bursts,
     get_region_of_interest
 )
+from hyp3_isce2.s1_auxcal import download_aux_cal
 
 
 log = logging.getLogger(__name__)
@@ -49,6 +50,7 @@ def topsapp_burst(
         range_looks: Number of range looks
     """
     orbit_dir = 'orbits'
+    aux_cal_dir = 'aux_cal'
     ref_params = BurstParams(reference_scene, f'IW{swath_number}', polarization.upper(), reference_burst_number)
     sec_params = BurstParams(secondary_scene, f'IW{swath_number}', polarization.upper(), secondary_burst_number)
     ref_metadata, sec_metadata = download_bursts([ref_params, sec_params])
@@ -57,9 +59,11 @@ def topsapp_burst(
     insar_roi = get_region_of_interest(ref_metadata.footprint, sec_metadata.footprint, is_ascending=is_ascending)
     dem_roi = ref_metadata.footprint.intersection(sec_metadata.footprint).bounds
     print(insar_roi, dem_roi)
-
+    
+    download_aux_cal(aux_cal_dir)
     for granule in (ref_params.granule, sec_params.granule):
         orbit_file, _ = downloadSentinelOrbitFile(granule, orbit_dir)
+
     # TODO replace with the actual processing call once we have the functionality for downloading the input data
     subprocess.run(['python', TOPSAPP, '-h'])
 

--- a/src/hyp3_isce2/s1_auxcal.py
+++ b/src/hyp3_isce2/s1_auxcal.py
@@ -50,7 +50,7 @@ def download_aux_cal(aux_cal_dir: Union[str, Path] = 'aux_cal'):
         aux_cal_dir = Path(aux_cal_dir)
 
     aux_cal_dir.mkdir(exist_ok=True, parents=True)
-    for url in [S1A_AUX_URL, S1B_AUX_URL]:
+    for url in (S1A_AUX_URL, S1B_AUX_URL):
         _download_platform(url, aux_cal_dir)
 
 

--- a/src/hyp3_isce2/s1_auxcal.py
+++ b/src/hyp3_isce2/s1_auxcal.py
@@ -32,10 +32,10 @@ def _download_platform(url: str, aux_cal_dir: Path):
         url: URL to download the aux cal files from.
         aux_cal_dir: Directory to download the aux cal files to.
     """
-    resp = requests.get(url)
-    resp.raise_for_status()
+    response = requests.get(url)
+    response.raise_for_status()
 
-    content = BytesIO(resp.content)
+    content = BytesIO(response.content)
     with zipfile.ZipFile(content) as zip_file:
         zip_file.extractall(aux_cal_dir)
 
@@ -55,5 +55,4 @@ def download_aux_cal(aux_cal_dir: Union[str, Path] = 'aux_cal'):
 
 
 if __name__ == '__main__':
-    # Provides a command line interface to download the aux cal files
     download_aux_cal()

--- a/src/hyp3_isce2/s1_auxcal.py
+++ b/src/hyp3_isce2/s1_auxcal.py
@@ -25,7 +25,13 @@ S1A_AUX_URL = 'https://sar-mpc.eu/download/55282da1-679d-4ecf-aeef-d06b024451cf'
 S1B_AUX_URL = 'https://sar-mpc.eu/download/3c8b7c8d-d3de-4381-a19d-7611fb8734b9'
 
 
-def download_platform(url, aux_cal_dir):
+def _download_platform(url: str, aux_cal_dir: Path):
+    """Download and extract the aux cal files for a given satellite platform.
+
+    Args:
+        url: URL to download the aux cal files from.
+        aux_cal_dir: Directory to download the aux cal files to.
+    """
     resp = requests.get(url)
     resp.raise_for_status()
 
@@ -35,13 +41,19 @@ def download_platform(url, aux_cal_dir):
 
 
 def download_aux_cal(aux_cal_dir: Union[str, Path] = 'aux_cal'):
+    """Download and extract the aux cal files for Sentinel-1A/B.
+
+    Args:
+        aux_cal_dir: Directory to download the aux cal files to.
+    """
     if not isinstance(aux_cal_dir, Path):
         aux_cal_dir = Path(aux_cal_dir)
 
     aux_cal_dir.mkdir(exist_ok=True, parents=True)
     for url in [S1A_AUX_URL, S1B_AUX_URL]:
-        download_platform(url, aux_cal_dir)
+        _download_platform(url, aux_cal_dir)
 
 
 if __name__ == '__main__':
+    """Provides a command line interface to download the aux cal files."""
     download_aux_cal()

--- a/src/hyp3_isce2/s1_auxcal.py
+++ b/src/hyp3_isce2/s1_auxcal.py
@@ -1,0 +1,48 @@
+# Copyright 2021-present Caltech
+# Modifications Copyright 2023 Alaska Satellite Facility
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import zipfile
+from pathlib import Path
+from typing import Union
+
+import requests
+
+S1A_AUX_URL = 'https://sar-mpc.eu/download/55282da1-679d-4ecf-aeef-d06b024451cf'
+S1B_AUX_URL = 'https://sar-mpc.eu/download/3c8b7c8d-d3de-4381-a19d-7611fb8734b9'
+
+
+def download_aux_cal(aux_cal_dir: Union[str, Path] = None):
+    aux_cal_dir = aux_cal_dir or 'aux_cal'
+    aux_cal_dir = Path(aux_cal_dir)
+    aux_cal_dir.mkdir(exist_ok=True, parents=True)
+
+    def download_one(url):
+        resp = requests.get(url)
+        file_name = url.split('/')[-1]
+        out_path = aux_cal_dir/file_name
+
+        with open(out_path, 'wb') as file:
+            file.write(resp.content)
+        return out_path
+
+    s1a_path = download_one(S1A_AUX_URL)
+    s1b_path = download_one(S1B_AUX_URL)
+
+    with zipfile.ZipFile(s1a_path) as zip_file:
+        zip_file.extractall(aux_cal_dir)
+    with zipfile.ZipFile(s1b_path) as zip_file:
+        zip_file.extractall(aux_cal_dir)
+
+    return {'aux_cal_dir': str(aux_cal_dir)}

--- a/src/hyp3_isce2/s1_auxcal.py
+++ b/src/hyp3_isce2/s1_auxcal.py
@@ -55,5 +55,5 @@ def download_aux_cal(aux_cal_dir: Union[str, Path] = 'aux_cal'):
 
 
 if __name__ == '__main__':
-    """Provides a command line interface to download the aux cal files."""
+    # Provides a command line interface to download the aux cal files
     download_aux_cal()

--- a/src/hyp3_isce2/s1_auxcal.py
+++ b/src/hyp3_isce2/s1_auxcal.py
@@ -14,35 +14,34 @@
 # limitations under the License.
 
 import zipfile
+from io import BytesIO
 from pathlib import Path
 from typing import Union
 
 import requests
 
+
 S1A_AUX_URL = 'https://sar-mpc.eu/download/55282da1-679d-4ecf-aeef-d06b024451cf'
 S1B_AUX_URL = 'https://sar-mpc.eu/download/3c8b7c8d-d3de-4381-a19d-7611fb8734b9'
 
 
-def download_aux_cal(aux_cal_dir: Union[str, Path] = None):
-    aux_cal_dir = aux_cal_dir or 'aux_cal'
-    aux_cal_dir = Path(aux_cal_dir)
+def download_platform(url, aux_cal_dir):
+    resp = requests.get(url)
+    resp.raise_for_status()
+
+    content = BytesIO(resp.content)
+    with zipfile.ZipFile(content) as zip_file:
+        zip_file.extractall(aux_cal_dir)
+
+
+def download_aux_cal(aux_cal_dir: Union[str, Path] = 'aux_cal'):
+    if not isinstance(aux_cal_dir, Path):
+        aux_cal_dir = Path(aux_cal_dir)
+
     aux_cal_dir.mkdir(exist_ok=True, parents=True)
+    for url in [S1A_AUX_URL, S1B_AUX_URL]:
+        download_platform(url, aux_cal_dir)
 
-    def download_one(url):
-        resp = requests.get(url)
-        file_name = url.split('/')[-1]
-        out_path = aux_cal_dir/file_name
 
-        with open(out_path, 'wb') as file:
-            file.write(resp.content)
-        return out_path
-
-    s1a_path = download_one(S1A_AUX_URL)
-    s1b_path = download_one(S1B_AUX_URL)
-
-    with zipfile.ZipFile(s1a_path) as zip_file:
-        zip_file.extractall(aux_cal_dir)
-    with zipfile.ZipFile(s1b_path) as zip_file:
-        zip_file.extractall(aux_cal_dir)
-
-    return {'aux_cal_dir': str(aux_cal_dir)}
+if __name__ == '__main__':
+    download_aux_cal()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def tempdir():
+    with tempfile.TemporaryDirectory() as tempdir:
+        yield tempdir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,0 @@
-import tempfile
-
-import pytest
-
-
-@pytest.fixture()
-def tempdir():
-    with tempfile.TemporaryDirectory() as tempdir:
-        yield tempdir

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -56,12 +56,11 @@ def test_create_geometry():
         '*SAFE/annotation/calibration/noise*xml',
     ),
 )
-def test_spoof_safe(tempdir, mocker, pattern):
+def test_spoof_safe(tmp_path, mocker, pattern):
     ref_burst = burst.BurstMetadata(load_metadata('reference_descending.xml'), REF_DESC)
-    tempdir_path = Path(tempdir)
     mocker.patch('hyp3_isce2.burst.download_burst', return_value='')
-    burst.spoof_safe(requests.Session(), ref_burst, tempdir_path)
-    assert len(list(tempdir_path.glob(pattern))) == 1
+    burst.spoof_safe(requests.Session(), ref_burst, tmp_path)
+    assert len(list(tmp_path.glob(pattern))) == 1
 
 
 @pytest.mark.parametrize('orbit', ('ascending', 'descending'))

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -1,4 +1,3 @@
-import tempfile
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -21,12 +20,6 @@ def load_metadata(metadata):
     metadata_path = Path(__file__).parent.absolute() / 'data' / metadata
     xml = ET.parse(metadata_path).getroot()
     return xml
-
-
-@pytest.fixture()
-def tempdir():
-    with tempfile.TemporaryDirectory() as tempdir:
-        yield tempdir
 
 
 def test_create_gcp_df():

--- a/tests/test_s1_auxcal.py
+++ b/tests/test_s1_auxcal.py
@@ -1,18 +1,13 @@
-import tempfile
 from pathlib import Path
-
-import pytest
 
 from hyp3_isce2 import s1_auxcal
 
 
-@pytest.fixture()
-def tempdir():
-    with tempfile.TemporaryDirectory() as tempdir:
-        yield tempdir
-
-
 def test_download_aux_cal(tempdir):
+    """This test is slow because it download ~3MB of data.
+    Might want to consider skipping unless doing integration testing.
+    """
+
     aux_cal_dir = Path(tempdir) / 'aux_cal'
     s1_auxcal.download_aux_cal(aux_cal_dir)
     assert (aux_cal_dir / 'S1A_AUX_CAL_V20190228T092500_G20210104T141310.SAFE').exists()

--- a/tests/test_s1_auxcal.py
+++ b/tests/test_s1_auxcal.py
@@ -1,0 +1,19 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from hyp3_isce2 import s1_auxcal
+
+
+@pytest.fixture()
+def tempdir():
+    with tempfile.TemporaryDirectory() as tempdir:
+        yield tempdir
+
+
+def test_download_aux_cal(tempdir):
+    aux_cal_dir = Path(tempdir) / 'aux_cal'
+    s1_auxcal.download_aux_cal(aux_cal_dir)
+    assert (aux_cal_dir / 'S1A_AUX_CAL_V20190228T092500_G20210104T141310.SAFE').exists()
+    assert (aux_cal_dir / 'S1B_AUX_CAL_V20190514T090000_G20210104T140612.SAFE').exists()

--- a/tests/test_s1_auxcal.py
+++ b/tests/test_s1_auxcal.py
@@ -1,14 +1,12 @@
-from pathlib import Path
-
 from hyp3_isce2 import s1_auxcal
 
 
-def test_download_aux_cal(tempdir):
+def test_download_aux_cal(tmp_path):
     """This test is slow because it download ~3MB of data.
     Might want to consider skipping unless doing integration testing.
     """
 
-    aux_cal_dir = Path(tempdir) / 'aux_cal'
+    aux_cal_dir = tmp_path / 'aux_cal'
     s1_auxcal.download_aux_cal(aux_cal_dir)
     assert (aux_cal_dir / 'S1A_AUX_CAL_V20190228T092500_G20210104T141310.SAFE').exists()
     assert (aux_cal_dir / 'S1B_AUX_CAL_V20190514T090000_G20210104T140612.SAFE').exists()


### PR DESCRIPTION
Adds the ability to download Sentinel-1 orbits and auxiliary calibration files.

The `s1_auxcal` test is slow because it downloads/extracts the data from the ESA archives. Might want to consider adding a `pytest` marker so it is only run during integration testing.