### PR TITLE
Get topsapp steps for bursts to run successfully

### DIFF
--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -119,8 +119,7 @@ def create_burst_request_url(params: BurstParams, content_type: str) -> str:
     """
     filetypes = {'metadata': 'xml', 'geotiff': 'tiff'}
     extension = filetypes[content_type]
-    burst_number_zero_indexed = params.burst_number - 1
-    url = f'{URL}/{params.granule}/{params.swath}/{params.polarization}/{burst_number_zero_indexed}.{extension}'
+    url = f'{URL}/{params.granule}/{params.swath}/{params.polarization}/{params.burst_number}.{extension}'
     return url
 
 
@@ -159,7 +158,7 @@ def download_from_extractor(asf_session: requests.Session, burst_params: BurstPa
     }
 
     for i in range(1, 11):
-        print(f'Download attempt #{i}')
+        print(f'Download attempt #{i} for {burst_request["url"]}')
         response = asf_session.get(**burst_request)
         downloaded = wait_for_extractor(response)
         if downloaded:

--- a/src/hyp3_isce2/process.py
+++ b/src/hyp3_isce2/process.py
@@ -11,6 +11,7 @@ from hyp3lib.get_orb import downloadSentinelOrbitFile
 from hyp3_isce2 import __version__
 from hyp3_isce2 import topsapp
 from hyp3_isce2.burst import BurstParams, download_bursts, get_region_of_interest
+from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.s1_auxcal import download_aux_cal
 
 
@@ -34,7 +35,7 @@ def topsapp_burst(
         secondary_scene: Secondary SLC name
         swath_number: Number of swath to grab bursts from (1, 2, or 3) for IW
         reference_burst_number: Number of burst to download for reference (0-indexed from first collect)
-        secondary_burst_numbe: Number of burst to download for secondary (0-indexed from first collect)
+        secondary_burst_number: Number of burst to download for secondary (0-indexed from first collect)
         polarization: Polarization to use
         azimuth_looks: Number of azimuth looks
         range_looks: Number of range looks
@@ -51,21 +52,20 @@ def topsapp_burst(
     print(f'InSAR ROI: {insar_roi}')
     print(f'DEM ROI: {dem_roi}')
 
-    # TODO placeholder for downloading the DEM
-    dem_filename = 'dem.tif'
+    dem_path = download_dem_for_isce2(dem_roi, dem_name='glo_30', dem_dir=Path('dem'), buffer=0)
     download_aux_cal(aux_cal_dir)
 
     orbit_dir.mkdir(exist_ok=True, parents=True)
     for granule in (ref_params.granule, sec_params.granule):
-        downloadSentinelOrbitFile(granule, orbit_dir)
+        downloadSentinelOrbitFile(granule, str(orbit_dir))
 
     config = topsapp.TopsappBurstConfig(
         reference_safe=f'{ref_params.granule}.SAFE',
         secondary_safe=f'{sec_params.granule}.SAFE',
-        orbit_directory=orbit_dir,
-        aux_cal_directory=aux_cal_dir,
+        orbit_directory=str(orbit_dir),
+        aux_cal_directory=str(aux_cal_dir),
         region_of_interest=insar_roi,
-        dem_filename=dem_filename,
+        dem_filename=str(dem_path),
         swath=swath_number,
         azimuth_looks=azimuth_looks,
         range_looks=range_looks,

--- a/src/hyp3_isce2/process.py
+++ b/src/hyp3_isce2/process.py
@@ -48,7 +48,8 @@ def topsapp_burst(
     is_ascending = ref_metadata.orbit_direction == 'ascending'
     insar_roi = get_region_of_interest(ref_metadata.footprint, sec_metadata.footprint, is_ascending=is_ascending)
     dem_roi = ref_metadata.footprint.intersection(sec_metadata.footprint).bounds
-    print(insar_roi, dem_roi)
+    print(f'InSAR ROI: {insar_roi}')
+    print(f'DEM ROI: {dem_roi}')
 
     # TODO placeholder for downloading the DEM
     dem_filename = 'dem.tif'
@@ -74,7 +75,7 @@ def topsapp_burst(
     for step in topsapp.TOPSAPP_STEPS:
         if step == 'computeBaselines':
             topsapp.swap_burst_vrts()
-        topsapp.run_topsapp_burst(dostep=step, config_xml='topsApp.xml')
+        topsapp.run_topsapp_burst(dostep=step, config_xml=Path('topsApp.xml'))
 
     return None
 

--- a/src/hyp3_isce2/topsapp.py
+++ b/src/hyp3_isce2/topsapp.py
@@ -115,21 +115,24 @@ def swap_burst_vrts():
     To convince topsApp to process a burst pair, we need to swap the VRTs it generates for the
     reference and secondary bursts with custom VRTs that point to the actual burst rasters.
     """
-    ref_vrt_list = [str(x) for x in Path('reference').glob('**/*.vrt')]
-    sec_vrt_list = [str(x) for x in Path('secondary').glob('**/*.vrt')]
-    if len(ref_vrt_list) + len(sec_vrt_list) != 2:
+    ref_vrt_list = [str(path) for path in Path('reference').glob('**/*.vrt')]
+    sec_vrt_list = [str(path) for path in Path('secondary').glob('**/*.vrt')]
+    if len(ref_vrt_list) != 1 or len(sec_vrt_list) != 1:
         raise ValueError(
             'There should only be 2 VRT files in the reference and secondary directories, '
             'check that you are performing a single burst run.'
         )
 
-    for vrt_list in (ref_vrt_list, sec_vrt_list):
-        vrt = gdal.Open(vrt_list[0])
+    for vrt_path in (ref_vrt_list[0], sec_vrt_list[0]):
+        vrt = gdal.Open(vrt_path)
         base = gdal.Open(vrt.GetFileList()[1])
-        vrt_shape, base_shape = [(x.RasterXSize, x.RasterYSize) for x in (vrt, base)]
+
+        # FIXME these variables are not used, are they needed?
+        # vrt_shape, base_shape = [(x.RasterXSize, x.RasterYSize) for x in (vrt, base)]
+
         del vrt
 
-        gdal.Translate(vrt_list[0], base, format='VRT')
+        gdal.Translate(vrt_path, base, format='VRT')
         del base
 
 

--- a/src/hyp3_isce2/topsapp.py
+++ b/src/hyp3_isce2/topsapp.py
@@ -151,7 +151,7 @@ def run_topsapp_burst(dostep: str = '', start: str = '', stop: str = '', config_
         ValueError: If the step is not a valid step (see TOPSAPP_STEPS)
     """
     if not config_xml.exists():
-        raise IOError(f'The config file {config_xml} doe not exist!')
+        raise IOError(f'The config file {config_xml} does not exist!')
 
     if dostep and (start or stop):
         raise ValueError('If dostep is specified, start and stop cannot be used')

--- a/tests/test_topsapp.py
+++ b/tests/test_topsapp.py
@@ -30,6 +30,11 @@ def test_topsapp_burst_config(tmp_path):
         assert '[-118.0, 37.0, -117.0, 38.0]' in template
         assert '[1]' in template
 
+
+def test_swap_burst_vrts():
+    assert False
+
+
 def test_run_topsapp_burst(tmp_path):
     with pytest.raises(IOError):
         run_topsapp_burst('topsApp.xml')


### PR DESCRIPTION
The purpose of this PR was to add test(s) for the `swap_burst_vrts` function, but first I decided to try to run `process.py` to get some example VRTs to play with. I believe I've gotten it to run far enough to create the VRTs, but now I'd like to get it to run all the way through. I'm running the following command:

```
python src/hyp3_isce2/process.py --reference-scene S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8 --secondary-scene S1A_IW_SLC__1SSV_20150504T120217_20150504T120229_005771_00769E_EF9A --swath-number 1 --reference-burst-number 1 --secondary-burst-number 1
```

After several minor bugfixes, it's now failing with `imageMath.py: not found`. Here's the last part of the log:

```
snaphu v1.4.2
Reading unwrapped phase from file merged/filt_topophase.unw
No weight file specified.  Assuming uniform weights
Reading correlation data from file merged/phsig.cor
Calculating smooth-solution cost parameters
Growing connected component mask
Writing connected components to file merged/filt_topophase.unw.conncomp
API open (R): merged/filt_topophase.unw
API close:  merged/filt_topophase.unw
GDAL open (R): merged/filt_topophase.unw.vrt
GDAL close: merged/filt_topophase.unw.vrt
API open (R): merged/filt_topophase.unw.conncomp
API close:  merged/filt_topophase.unw.conncomp
GDAL open (R): merged/filt_topophase.unw.conncomp.vrt
GDAL close: merged/filt_topophase.unw.conncomp.vrt
imageMath.py -e='a_0*(abs(b)!=0);a_1*(abs(b)!=0)' --a=tmp.unw --b=merged/filt_topophase.flat -s BIL -o=merged/filt_topophase.unw
sh: 1: imageMath.py: not found
Traceback (most recent call last):
  File "/home/jth/code/hyp3-isce2/temp/../src/hyp3_isce2/process.py", line 101, in <module>
    main()
  File "/home/jth/code/hyp3-isce2/temp/../src/hyp3_isce2/process.py", line 97, in main
    topsapp_burst(**args.__dict__)
  File "/home/jth/code/hyp3-isce2/temp/../src/hyp3_isce2/process.py", line 78, in topsapp_burst
    topsapp.run_topsapp_burst(dostep=step, config_xml=Path('topsApp.xml'))
  File "/home/jth/code/hyp3-isce2/src/hyp3_isce2/topsapp.py", line 175, in run_topsapp_burst
    insar.run()
  File "/home/jth/jth-apps/miniconda3/envs/hyp3-isce2/lib/python3.9/site-packages/isce/components/iscesys/Component/Application.py", line 142, in run
    exitStatus = self._processSteps()
  File "/home/jth/jth-apps/miniconda3/envs/hyp3-isce2/lib/python3.9/site-packages/isce/components/iscesys/Component/Application.py", line 405, in _processSteps
    result = func(*pargs, **kwargs)
  File "/home/jth/jth-apps/miniconda3/envs/hyp3-isce2/lib/python3.9/site-packages/isce/components/isceobj/TopsProc/Factories.py", line 40, in __call__
    return self.method(self.other, *args, **kwargs)
  File "/home/jth/jth-apps/miniconda3/envs/hyp3-isce2/lib/python3.9/site-packages/isce/components/isceobj/TopsProc/runUnwrapSnaphu.py", line 132, in runUnwrapMcf
    runUnwrap(self,costMode = 'SMOOTH',initMethod = 'MCF', defomax = 2, initOnly = True)
  File "/home/jth/jth-apps/miniconda3/envs/hyp3-isce2/lib/python3.9/site-packages/isce/components/isceobj/TopsProc/runUnwrapSnaphu.py", line 126, in runUnwrap
    maskUnwrap(unwrapName, wrapName)
  File "/home/jth/jth-apps/miniconda3/envs/hyp3-isce2/lib/python3.9/site-packages/isce/components/isceobj/TopsProc/runIon.py", line 816, in maskUnwrap
    runCmd(cmd)
  File "/home/jth/jth-apps/miniconda3/envs/hyp3-isce2/lib/python3.9/site-packages/isce/components/isceobj/TopsProc/runIon.py", line 294, in runCmd
    raise Exception('error when running:\n{}\n'.format(cmd))
Exception: error when running:
imageMath.py -e='a_0*(abs(b)!=0);a_1*(abs(b)!=0)' --a=tmp.unw --b=merged/filt_topophase.flat -s BIL -o=merged/filt_topophase.unw
```

TODO:

- [ ] Debug the error shown above.
- [ ] https://github.com/ASFHyP3/hyp3-isce2/issues/14