### PR TITLE
Concurrent downloads

### DIFF
--- a/src/hyp3_isce2/etc/download_example.py
+++ b/src/hyp3_isce2/etc/download_example.py
@@ -24,4 +24,4 @@ with get_asf_session() as session:
 
 # Example 2
 # Download with SAFE spoofing
-download_bursts([ref_asc, sec_desc])
+download_bursts([ref_desc, sec_desc])

--- a/src/hyp3_isce2/etc/download_example.py
+++ b/src/hyp3_isce2/etc/download_example.py
@@ -5,20 +5,23 @@ hyp3_isce2.burst module.
 
 Example 1: Downloading metadata for a pair of ascending/descending bursts
             (these are the metadata files used in the test suite.)
+
+Example 2: Downloading a pair of ascending/descending bursts and spoofing a SAFE
 """
 
-from hyp3_isce2.burst import (
-    BurstParams,
-    download_metadata,
-    get_asf_session
-)
+from hyp3_isce2.burst import BurstParams, download_bursts, download_metadata, get_asf_session
 
-# Example 1
 ref_desc = BurstParams('S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85', 'IW2', 'VV', 3)
 sec_desc = BurstParams('S1A_IW_SLC__1SDV_20200616T022252_20200616T022319_033036_03D3A3_5D11', 'IW2', 'VV', 3)
 ref_asc = BurstParams('S1A_IW_SLC__1SDV_20211229T231926_20211229T231953_041230_04E66A_3DBE', 'IW1', 'VV', 4)
 sec_asc = BurstParams('S1A_IW_SLC__1SDV_20220110T231926_20220110T231953_041405_04EC57_103E', 'IW1', 'VV', 4)
 
-session = get_asf_session()
-download_metadata(session, ref_asc, 'data/reference_ascending.xml')
-download_metadata(session, sec_desc, 'data/secondary_ascending.xml')
+# Example 1
+# Download metadata files
+with get_asf_session() as session:
+    download_metadata(session, ref_asc, 'data/reference_ascending.xml')
+    download_metadata(session, sec_desc, 'data/secondary_ascending.xml')
+
+# Example 2
+# Download with SAFE spoofing
+download_bursts([ref_asc, sec_desc])


### PR DESCRIPTION
Waiting on the burst extractor in serial to perform data downloads was taking up a large percentage of the total processing time. This PR refactors the `download_bursts` function to concurrently download the data we need, significantly decreasing the overall processing time.