### PR TITLE
Fix 0-index bug in burst.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3]
+### Fixed
+* A zero-index bug in `burst.py` that led to incorrect geolocation of products
+
 ## [0.1.2]
 ### Added
 * Concurrent download functionality for burst extractor calls.

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -92,10 +92,9 @@ class BurstMetadata:
         Returns:
             A tuple containing the shapely polygon, bounding box, and centroid for the burst.
         """
-        burst_index = self.burst_number - 1
         lines = int(self.annotation.findtext('.//{*}linesPerBurst'))
-        first_line = gcp_df.loc[gcp_df['line'] == burst_index * lines, ['longitude', 'latitude']]
-        second_line = gcp_df.loc[gcp_df['line'] == (burst_index + 1) * lines, ['longitude', 'latitude']]
+        first_line = gcp_df.loc[gcp_df['line'] == self.burst_number * lines, ['longitude', 'latitude']]
+        second_line = gcp_df.loc[gcp_df['line'] == (self.burst_number + 1) * lines, ['longitude', 'latitude']]
         x1 = first_line['longitude'].tolist()
         y1 = first_line['latitude'].tolist()
         x2 = second_line['longitude'].tolist()


### PR DESCRIPTION
In an earlier update, we changed to using zero-indexed burst numbers but did not switch over to this paradigm in the `create_geometry` method. 