### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,5 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.7.1
     with:
       release_prefix: HyP3 ISCE2
-      release_branch: main
-      develop_branch: develop
-      sync_pr_label: actions-bot
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}


### PR DESCRIPTION
Since this is our plugin, we can use the defaults here. Also, this switches back to using the `tools-bot` label as we do for all our other repos and because we're using the Tools Bot access key. 