### PR TITLE
Add ability to pass EarthData credentials as environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.3.0]
 ### Added
 * `insar_tops` workflow for processing of full Sentinel-1 SLCs.
-* Ability to pass EarthData username and password as environment variables to workflows. This allows the credentials to be passed to the docker container via a `-e` command.
+* Ability to pass EarthData username and password as environment variables to workflows. This allows the credentials to be passed to the Docker container via the `-e` option.
 
 ## [0.2.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2]
+### Added
+* Ability to pass EarthData username and password as environment variables to workflows. This allows the credentials to be passed to the docker container via a `-e` command.
 
 ## [0.2.1]
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python -m hyp3_isce2 ++process insar_tops_burst \
 This command will create a Sentinel-1 interferogram that contains a deformation signal related to a 2020 Iranian earthquake.
 To learn about the arguments for each workflow, look at the help documentation (`python -m hyp3_isce2 ++process [WORKFLOW_NAME] --help`).
 
-For all workflows the user will need to provide their EarthData login credentials to download input data. If you do not already have an account, you can sign up [here](https://urs.earthdata.nasa.gov/home). Your credentials can either be passed to the workflows via environment variables (`EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD`), or via your `.netrc` file. If you haven't set up a `.netrc` file before, check out this [guide](https://harmony.earthdata.nasa.gov/docs#getting-started) to get started.
+For all workflows the user will need to provide their Earthdata login credentials to download input data. If you do not already have an account, you can sign up [here](https://urs.earthdata.nasa.gov/home). Your credentials can either be passed to the workflows via environment variables (`EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD`), or via your `.netrc` file. If you haven't set up a `.netrc` file before, check out this [guide](https://harmony.earthdata.nasa.gov/docs#getting-started) to get started.
 
 The ultimate goal of this project is to create a docker container that can run ISCE2 workflows within a HyP3 deployment. To run the current version of the project's container, use this command:
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ To learn about the arguments for each workflow, look at the help documentation (
 
 The ultimate goal of this project is to create a docker container that can run ISCE2 workflows within a HyP3 deployment. To run the current version of the project's container, use this command:
 ```
-docker run -it --rm ghcr.io/asfhyp3/hyp3-isce2:latest ++process [WORKFLOW_NAME] [WORKFLOW_ARGS]
+docker run -it --rm \
+    -e EARTHDATA_USERNAME=[YOUR_USERNAME_HERE] \
+    -e EARTHDATA_PASSWORD=[YOUR_PASSWORD_HERE] \
+    ghcr.io/asfhyp3/hyp3-isce2:latest \
+    ++process [WORKFLOW_NAME] \
+    [WORKFLOW_ARGS]
 ```
 
 **NOTE** Each workflow can also be accessed via an alternative CLI with the format (`[WORKFLOW_NAME] [WORKFLOW_ARGS]`)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 The HyP3-ISCE2 plugin provides a set of workflows to process SAR satellite data using the [InSAR Scientific Computing Environment 2](https://github.com/isce-framework/isce2) (ISCE2) software package. This plugin is part of the [Alaska Satellite Facility's](https://asf.alaska.edu) larger HyP3 (Hybrid Plugin Processing Pipeline) system, which is a batch processing pipeline designed for on-demand processing of SAR data.
 
 ## Usage
-The HyP3-ISCE2 plugin provides a set of workflows (accessable directly in Python or via a CLI) that can be used to process SAR data using ISCE2. The workflows currently included in this plugin are:
+The HyP3-ISCE2 plugin provides a set of workflows (accessible directly in Python or via a CLI) that can be used to process SAR data using ISCE2. The workflows currently included in this plugin are:
 
+- `insar_tops`: A workflow for creating full-SLC Sentinel-1 geocoded unwrapped interferogram using ISCE2's TOPS processing workflow 
 - `insar_tops_burst`: A workflow for creating single-burst Sentinel-1 geocoded unwrapped interferogram using ISCE2's TOPS processing workflow 
 ---
 
@@ -24,6 +25,8 @@ python -m hyp3_isce2 ++process insar_tops_burst \
 
 This command will create a Sentinel-1 interferogram that contains a deformation signal related to a 2020 Iranian earthquake.
 To learn about the arguments for each workflow, look at the help documentation (`python -m hyp3_isce2 ++process [WORKFLOW_NAME] --help`).
+
+For all workflows the user will need to provide their EarthData login credentials to download input data. If you do not already have an account, you can sign up [here](https://urs.earthdata.nasa.gov/home). Your credentials can either be passed to the workflows via environment variables (`EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD`), or via your `.netrc` file. If you haven't set up a `.netrc` file before, check out this [guide](https://harmony.earthdata.nasa.gov/docs#getting-started) to get started.
 
 The ultimate goal of this project is to create a docker container that can run ISCE2 workflows within a HyP3 deployment. To run the current version of the project's container, use this command:
 ```

--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -4,8 +4,8 @@ ISCE2 processing for HyP3
 import argparse
 import os
 import sys
-from pathlib import Path
 from importlib.metadata import entry_points
+from pathlib import Path
 
 from hyp3lib.fetch import write_credentials_to_netrc_file
 
@@ -18,11 +18,7 @@ def main():
     parser = argparse.ArgumentParser(prefix_chars='+', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         '++process',
-        choices=[
-            'insar_tops_burst',
-            'insar_tops',
-            'insar_stripmap'
-        ],
+        choices=['insar_tops_burst', 'insar_tops', 'insar_stripmap'],
         default='insar_tops_burst',
         help='Select the HyP3 entrypoint to use',  # HyP3 entrypoints are specified in `pyproject.toml`
     )
@@ -36,7 +32,6 @@ def main():
 
     if not (Path.home() / '.netrc').exists():
         raise ValueError('EarthData login credentials must be present as environment variables, or in your netrc')
-
 
     # NOTE: Cast to set because of: https://github.com/pypa/setuptools/issues/3649
     # NOTE: Will need to update to `entry_points(group='hyp3', name=args.process)` when updating to python 3.10

--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -32,9 +32,7 @@ def main():
         write_credentials_to_netrc_file(username, password, append=False)
 
     if not (Path.home() / '.netrc').exists():
-        warnings.warn(
-            'EarthData login credentials must be present as environment variables, or in your netrc.', UserWarning
-        )
+        warnings.warn('EarthData credentials must be present as environment variables, or in your netrc.', UserWarning)
 
     # NOTE: Cast to set because of: https://github.com/pypa/setuptools/issues/3649
     # NOTE: Will need to update to `entry_points(group='hyp3', name=args.process)` when updating to python 3.10

--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -4,6 +4,7 @@ ISCE2 processing for HyP3
 import argparse
 import os
 import sys
+from pathlib import Path
 from importlib.metadata import entry_points
 
 from hyp3lib.fetch import write_credentials_to_netrc_file
@@ -32,6 +33,10 @@ def main():
     password = os.getenv('EARTHDATA_PASSWORD')
     if username and password:
         write_credentials_to_netrc_file(username, password, append=False)
+
+    if not (Path.home() / '.netrc').exists():
+        raise ValueError('EarthData login credentials must be present as environment variables, or in your netrc')
+
 
     # NOTE: Cast to set because of: https://github.com/pypa/setuptools/issues/3649
     # NOTE: Will need to update to `entry_points(group='hyp3', name=args.process)` when updating to python 3.10

--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -4,9 +4,9 @@ ISCE2 processing for HyP3
 import argparse
 import os
 import sys
+import warnings
 from importlib.metadata import entry_points
 from pathlib import Path
-import warnings
 
 from hyp3lib.fetch import write_credentials_to_netrc_file
 

--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -28,7 +28,6 @@ def main():
 
     args, unknowns = parser.parse_known_args()
 
-    # NOTE: Earthdata username and password should be provided as environment variables, or be present in your .netrc
     username = os.getenv('EARTHDATA_USERNAME')
     password = os.getenv('EARTHDATA_PASSWORD')
     if username and password:

--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -6,6 +6,7 @@ import os
 import sys
 from importlib.metadata import entry_points
 from pathlib import Path
+import warnings
 
 from hyp3lib.fetch import write_credentials_to_netrc_file
 
@@ -31,7 +32,9 @@ def main():
         write_credentials_to_netrc_file(username, password, append=False)
 
     if not (Path.home() / '.netrc').exists():
-        raise ValueError('EarthData login credentials must be present as environment variables, or in your netrc')
+        warnings.warn(
+            'EarthData login credentials must be present as environment variables, or in your netrc.', UserWarning
+        )
 
     # NOTE: Cast to set because of: https://github.com/pypa/setuptools/issues/3649
     # NOTE: Will need to update to `entry_points(group='hyp3', name=args.process)` when updating to python 3.10

--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -2,8 +2,11 @@
 ISCE2 processing for HyP3
 """
 import argparse
+import os
 import sys
 from importlib.metadata import entry_points
+
+from hyp3lib.fetch import write_credentials_to_netrc_file
 
 
 def main():
@@ -14,15 +17,19 @@ def main():
     parser = argparse.ArgumentParser(prefix_chars='+', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         '++process',
-        choices=[
-            'insar_tops_burst',
-            'insar_stripmap'
-        ],
+        choices=['insar_tops_burst', 'insar_stripmap'],
         default='insar_tops_burst',
         help='Select the HyP3 entrypoint to use',  # HyP3 entrypoints are specified in `pyproject.toml`
     )
 
     args, unknowns = parser.parse_known_args()
+
+    # NOTE: Earthdata username and password should be provided as environment variables, or be present in your .netrc
+    username = os.getenv('EARTHDATA_USERNAME')
+    password = os.getenv('EARTHDATA_PASSWORD')
+    if username and password:
+        write_credentials_to_netrc_file(username, password, append=False)
+
     # NOTE: Cast to set because of: https://github.com/pypa/setuptools/issues/3649
     # NOTE: Will need to update to `entry_points(group='hyp3', name=args.process)` when updating to python 3.10
     eps = entry_points()['hyp3']


### PR DESCRIPTION
This capability is the preferred way to pass the user's credentials to the docker container. I've checked this functionality by building a local version of this container `docker build -t hyp3-isce2:latest .` using the `credentials` branch then running:

```bash
docker run -it --rm \
    -e EARTHDATA_USERNAME={YOUR_USERNAME_HERE} \
    -e EARTHDATA_PASSWORD={YOUR_PASSWORD_HERE} \
    hyp3-isce2:latest \
    ++process insar_tops_burst \
    --reference-scene S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85 \
    --secondary-scene S1A_IW_SLC__1SDV_20200616T022252_20200616T022319_033036_03D3A3_5D11 \
    --swath-number 2 \
    --polarization VV \
    --reference-burst-number 7 \
    --secondary-burst-number 7 \
    --azimuth-looks 4 --range-looks 20
```

This worked as expected.

This PR does not create functionality to pass credentials as arguments to the workflows. I'd prefer to not add this functionality and instead limit credential passing to either a `.netrc` or as environment variables.