### PR TITLE
Unwrapped phase browse image

### DIFF
--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -117,7 +117,6 @@ def make_parameter_file(out_path: Path, reference_scene: str, secondary_scene: s
 
 def make_browse_image(input_tif: str, output_png: str) -> None:
     stats = gdal.Info(input_tif, format='json', stats=True)['stac']['raster:bands'][0]['stats']
-    breakpoint()
     gdal.Translate(
         destName=output_png,
         srcDS=input_tif,

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -24,7 +24,7 @@ from hyp3_isce2.burst import (
 )
 from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.s1_auxcal import download_aux_cal
-from hyp3_isce2.utils import extent_from_geotransform, utm_from_lon_lat
+from hyp3_isce2.utils import extent_from_geotransform, utm_from_lon_lat, make_browse_image
 
 log = logging.getLogger(__name__)
 
@@ -115,19 +115,6 @@ def make_parameter_file(out_path: Path, reference_scene: str, secondary_scene: s
         json.dump(output, f)
 
 
-def make_browse_image(input_tif: str, output_png: str) -> None:
-    stats = gdal.Info(input_tif, format='json', stats=True)['stac']['raster:bands'][0]['stats']
-    gdal.Translate(
-        destName=output_png,
-        srcDS=input_tif,
-        format='png',
-        outputType=gdal.GDT_Byte,
-        width=2048,
-        strict=True,
-        scaleParams=[[stats['minimum'], stats['maximum']]],
-    )
-
-
 def translate_outputs(product_dir: Path, product_name: str):
     """Translate ISCE outputs to a standard GTiff format with a UTMS projection
 
@@ -142,10 +129,6 @@ def translate_outputs(product_dir: Path, product_name: str):
         format='GTiff',
         noData=0,
         creationOptions=['TILED=YES', 'COMPRESS=LZW', 'NUM_THREADS=ALL_CPUS'],
-    )
-    make_browse_image(
-        f'{product_name}/{product_name}_unw_phase.tif',
-        f'{product_name}/{product_name}_unw_phase.png'
     )
     gdal.Translate(
         destName=f'{product_name}/{product_name}_corr.tif',
@@ -211,6 +194,11 @@ def translate_outputs(product_dir: Path, product_name: str):
         format='GTiff',
         dstSRS=f'epsg:{epsg}',
         creationOptions=['TILED=YES', 'COMPRESS=LZW', 'NUM_THREADS=ALL_CPUS'],
+    )
+
+    make_browse_image(
+        f'{product_name}/{product_name}_unw_phase.tif',
+        f'{product_name}/{product_name}_unw_phase.png'
     )
 
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -25,7 +25,7 @@ from hyp3_isce2.burst import (
 )
 from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.s1_auxcal import download_aux_cal
-from hyp3_isce2.utils import extent_from_geotransform, make_browse_image, utm_from_lon_lat
+from hyp3_isce2.utils import make_browse_image, utm_from_lon_lat
 
 log = logging.getLogger(__name__)
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -25,7 +25,7 @@ from hyp3_isce2.burst import (
 )
 from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.s1_auxcal import download_aux_cal
-from hyp3_isce2.utils import extent_from_geotransform, utm_from_lon_lat, make_browse_image
+from hyp3_isce2.utils import extent_from_geotransform, make_browse_image, utm_from_lon_lat
 
 log = logging.getLogger(__name__)
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -115,6 +115,20 @@ def make_parameter_file(out_path: Path, reference_scene: str, secondary_scene: s
         json.dump(output, f)
 
 
+def make_browse_image(input_tif: str, output_png: str) -> None:
+    stats = gdal.Info(input_tif, format='json', stats=True)['stac']['raster:bands'][0]['stats']
+    breakpoint()
+    gdal.Translate(
+        destName=output_png,
+        srcDS=input_tif,
+        format='png',
+        outputType=gdal.GDT_Byte,
+        width=2048,
+        strict=True,
+        scaleParams=[[stats['minimum'], stats['maximum']]],
+    )
+
+
 def translate_outputs(product_dir: Path, product_name: str):
     """Translate ISCE outputs to a standard GTiff format with a UTMS projection
 
@@ -129,6 +143,10 @@ def translate_outputs(product_dir: Path, product_name: str):
         format='GTiff',
         noData=0,
         creationOptions=['TILED=YES', 'COMPRESS=LZW', 'NUM_THREADS=ALL_CPUS'],
+    )
+    make_browse_image(
+        f'{product_name}/{product_name}_unw_phase.tif',
+        f'{product_name}/{product_name}_unw_phase.png'
     )
     gdal.Translate(
         destName=f'{product_name}/{product_name}_corr.tif',

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -27,7 +27,6 @@ from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.s1_auxcal import download_aux_cal
 from hyp3_isce2.utils import extent_from_geotransform, utm_from_lon_lat, make_browse_image
 
-
 log = logging.getLogger(__name__)
 
 # ISCE needs its applications to be on the system path.

--- a/src/hyp3_isce2/utils.py
+++ b/src/hyp3_isce2/utils.py
@@ -1,3 +1,6 @@
+from osgeo import gdal
+
+
 def utm_from_lon_lat(lon: float, lat: float) -> int:
     """Get the UTM zone epsg from a longitude and latitude.
 
@@ -31,3 +34,16 @@ def extent_from_geotransform(geotransform: tuple, x_size: int, y_size: int) -> t
         geotransform[3] + geotransform[5] * y_size,
     )
     return extent
+
+
+def make_browse_image(input_tif: str, output_png: str) -> None:
+    stats = gdal.Info(input_tif, format='json', stats=True)['stac']['raster:bands'][0]['stats']
+    gdal.Translate(
+        destName=output_png,
+        srcDS=input_tif,
+        format='png',
+        outputType=gdal.GDT_Byte,
+        width=2048,
+        strict=True,
+        scaleParams=[[stats['minimum'], stats['maximum']]],
+    )


### PR DESCRIPTION
Example:

`S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8_IW1_VV_1xS1A_IW_SLC__1SSV_20150504T120217_20150504T120229_005771_00769E_EF9A_IW1_VV_1_unw_phase.png`:

![S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8_IW1_VV_1xS1A_IW_SLC__1SSV_20150504T120217_20150504T120229_005771_00769E_EF9A_IW1_VV_1_unw_phase](https://github.com/ASFHyP3/hyp3-isce2/assets/19476938/fb294813-ce7f-4250-8f84-dd8f98796765)
