### PR TITLE
Add `++omp-num-threads` argument

### DIFF
--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -2,6 +2,7 @@
 ISCE2 processing for HyP3
 """
 import argparse
+import os
 import sys
 from importlib.metadata import entry_points
 
@@ -21,12 +22,17 @@ def main():
         default='insar_tops_burst',
         help='Select the HyP3 entrypoint to use',  # HyP3 entrypoints are specified in `pyproject.toml`
     )
+    parser.add_argument('++omp-num-threads', type=int, help='The number of OpenMP threads to use for parallel regions')
 
     args, unknowns = parser.parse_known_args()
     # NOTE: Cast to set because of: https://github.com/pypa/setuptools/issues/3649
     # NOTE: Will need to update to `entry_points(group='hyp3', name=args.process)` when updating to python 3.10
     eps = entry_points()['hyp3']
     (process_entry_point,) = {process for process in eps if process.name == args.process}
+
+    if args.omp_num_threads:
+        os.environ['OMP_NUM_THREADS'] = str(args.omp_num_threads)
+
     sys.argv = [args.process, *unknowns]
     sys.exit(process_entry_point.load()())
 


### PR DESCRIPTION
I tested this option with 4 threads and confirmed that I saw 4 threads being used in the log output, whereas I saw 8 threads without this option.