### PR TITLE
resolve insar_tops crash when attempting to geocode z.rdr.full.vrt

### DIFF
--- a/src/hyp3_isce2/insar_tops.py
+++ b/src/hyp3_isce2/insar_tops.py
@@ -6,7 +6,7 @@ import os
 import site
 import sys
 from pathlib import Path
-from shutil import make_archive
+from shutil import copyfile, make_archive
 
 from hyp3lib.aws import upload_file_to_s3
 from hyp3lib.get_orb import downloadSentinelOrbitFile
@@ -77,7 +77,9 @@ def insar_tops(
     )
     config_path = config.write_template('topsApp.xml')
 
-    topsapp.run_topsapp_burst(start='startup', end='geocode', config_xml=config_path)
+    topsapp.run_topsapp_burst(start='startup', end='unwrap2stage', config_xml=config_path)
+    copyfile('merged/z.rdr.full.xml', 'merged/z.rdr.full.vrt.xml')
+    topsapp.run_topsapp_burst(start='geocode', end='geocode', config_xml=config_path)
 
     return Path('merged')
 


### PR DESCRIPTION
Naive fix for https://github.com/ASFHyP3/hyp3-isce2/issues/65

```
$ insar_tops --reference-scene S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8 --secondary-scene S1A_IW_SLC__1SSV_20150504T120217_20150504T120229_005771_00769E_EF9A
2023-05-23 17:16:03,939 - hyp3_isce2.insar_tops - INFO - Begin ISCE2 TopsApp run
...
2023-05-23 17:39:29,478 - hyp3_isce2.insar_tops - INFO - ISCE2 TopsApp run completed successfully

$ ls -1 merged/z*
merged/z.rdr.full.geo
merged/z.rdr.full.geo.vrt
merged/z.rdr.full.geo.xml
merged/z.rdr.full.vrt
merged/z.rdr.full.vrt.xml
merged/z.rdr.full.xml
```
