### PR TITLE
initial draft of CMR UAT integration for insar_tops_burst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0]
 ### Changed
-* `insar_tops_burst` workflow now takes the burst product names rather than the slc product names
+* `insar_tops_burst` workflow now takes the burst product names rather than the SLC product names.
 
 ## [0.3.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.4.0]
+### Changed
+* `insar_tops_burst` workflow now takes the burst product names rather than the slc product names
+
 ## [0.3.0]
 ### Added
 * `insar_tops` workflow for processing of full Sentinel-1 SLCs.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,8 @@ To run a workflow, simply run `python -m hyp3_isce2 ++process [WORKFLOW_NAME] [W
 
 ```
 python -m hyp3_isce2 ++process insar_tops_burst \
-  --reference-scene S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85 \
-  --secondary-scene S1A_IW_SLC__1SDV_20200616T022252_20200616T022319_033036_03D3A3_5D11 \
-  --swath-number 2 \
-  --polarization VV \
-  --reference-burst-number 7 \
-  --secondary-burst-number 7 \
+  S1_249434_IW1_20230523T170733_VV_8850-BURST \
+  S1_249434_IW1_20230511T170732_VV_07DE-BURST \
   --azimuth-looks 4 \
   --range-looks 20
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - rasterio
   - shapely
   - jinja2
+  - asf_search>=6.4.0
   # For packaging, and testing
   - flake8
   - flake8-import-order

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, List, Optional, Tuple, Union
 
-import asf_search
 import isce  # noqa: F401
 import requests
 from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -328,7 +328,6 @@ def get_product_name(
     secondary_scene: str,
 ) -> str:
     """Get the name of the interferogram product.
-    NOTE: Will need to be updated when the interface changes.
 
     Args:
         reference_scene: The reference burst name.

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -327,25 +327,15 @@ def download_bursts(param_list: Iterator[BurstParams]) -> List[BurstMetadata]:
 def get_product_name(
     reference_scene: str,
     secondary_scene: str,
-    reference_burst_number: int,
-    secondary_burst_number: int,
-    swath_number: int,
-    polarization: str,
 ) -> str:
     """Get the name of the interferogram product.
     NOTE: Will need to be updated when the interface changes.
 
     Args:
-        reference_scene: The reference scene name.
-        secondary_scene: The secondary scene name.
-        reference_burst_number: The reference burst number.
-        secondary_burst_number: The secondary burst number.
-        swath_number: The swath number.
-        polarization: The polarization.
+        reference_scene: The reference burst scene name.
+        secondary_scene: The secondary burst scene name.
 
     Returns:
         The name of the interferogram product.
     """
-    reference_name = f'{reference_scene}_IW{swath_number}_{polarization}_{reference_burst_number}'
-    secondary_name = f'{secondary_scene}_IW{swath_number}_{polarization}_{secondary_burst_number}'
-    return f'{reference_name}x{secondary_name}'
+    return f'{reference_scene}x{secondary_scene}'

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, List, Optional, Tuple, Union
 
+import asf_search
 import isce  # noqa: F401
 import requests
 from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -331,8 +331,8 @@ def get_product_name(
     NOTE: Will need to be updated when the interface changes.
 
     Args:
-        reference_scene: The reference burst scene name.
-        secondary_scene: The secondary burst scene name.
+        reference_scene: The reference burst name.
+        secondary_scene: The secondary burst name.
 
     Returns:
         The name of the interferogram product.

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -53,6 +53,7 @@ def insar_tops_burst(
     Args:
         reference_scene: Reference burst name
         secondary_scene: Secondary burst name
+        swath_number: Number of swath to grab bursts from (1, 2, or 3) for IW
         azimuth_looks: Number of azimuth looks
         range_looks: Number of range looks
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -149,6 +149,7 @@ def make_parameter_file(
         out_path: path to output the parameter file
         reference_scene: Reference burst name
         secondary_scene: Secondary burst name
+        swath_number: Number of swath to grab bursts from (1, 2, or 3) for IW
         azimuth_looks: Number of azimuth looks
         range_looks: Number of range looks
         dem_name: Name of the DEM that is use

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -51,8 +51,8 @@ def insar_tops_burst(
     """Create a burst interferogram
 
     Args:
-        reference_scene: Reference SLC burst name
-        secondary_scene: Secondary SLC burst name
+        reference_scene: Reference burst name
+        secondary_scene: Secondary burst name
         azimuth_looks: Number of azimuth looks
         range_looks: Number of range looks
 
@@ -146,8 +146,8 @@ def make_parameter_file(
 
     Args:
         out_path: path to output the parameter file
-        reference_scene: The reference burst name
-        secondary_scene: The secondary burst name
+        reference_scene: Reference burst name
+        secondary_scene: Secondary burst name
         azimuth_looks: Number of azimuth looks
         range_looks: Number of range looks
         dem_name: Name of the DEM that is use

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -44,6 +44,7 @@ if str(ISCE_APPLICATIONS) not in os.environ['PATH'].split(os.pathsep):
 def insar_tops_burst(
     reference_scene: str,
     secondary_scene: str,
+    swath_number: int,
     azimuth_looks: int = 4,
     range_looks: int = 20,
 ) -> Path:
@@ -109,8 +110,6 @@ def insar_tops_burst(
     for granule in (ref_params.granule, sec_params.granule):
         downloadSentinelOrbitFile(granule, str(orbit_dir))
 
-    swath_number = int(reference_scene[12])
-
     config = topsapp.TopsappBurstConfig(
         reference_safe=f'{ref_params.granule}.SAFE',
         secondary_safe=f'{sec_params.granule}.SAFE',
@@ -137,6 +136,7 @@ def make_parameter_file(
     out_path: Path,
     reference_scene: str,
     secondary_scene: str,
+    swath_number: int,
     azimuth_looks: int = 4,
     range_looks: int = 20,
     dem_name: str = 'GLO_30',
@@ -192,7 +192,7 @@ def make_parameter_file(
     slant_range_time = float(ref_annotation_xml.find('.//slantRangeTime').text)
     range_sampling_rate = float(ref_annotation_xml.find('.//rangeSamplingRate').text)
     number_samples = int(ref_annotation_xml.find('.//swathTiming/samplesPerBurst').text)
-    baseline_perp = topsProc_xml.find(f'.//IW-{reference_scene[12]}_Bperp_at_midrange_for_first_common_burst').text
+    baseline_perp = topsProc_xml.find(f'.//IW-{swath_number}_Bperp_at_midrange_for_first_common_burst').text
     unwrapper_type = topsApp_xml.find('.//property[@name="unwrapper name"]').text
     phase_filter_strength = topsApp_xml.find('.//property[@name="filter strength"]').text
 
@@ -347,11 +347,14 @@ def main():
 
     log.info('Begin ISCE2 TopsApp run')
 
+    swath_number = int(args.granules[0][12])
+
     isce_output_dir = insar_tops_burst(
         reference_scene=args.granules[0],
         secondary_scene=args.granules[1],
         azimuth_looks=args.azimuth_looks,
         range_looks=args.range_looks,
+        swath_number=swath_number
     )
 
     log.info('ISCE2 TopsApp run completed successfully')
@@ -367,7 +370,8 @@ def main():
         reference_scene=args.granules[0],
         secondary_scene=args.granules[1],
         azimuth_looks=args.azimuth_looks,
-        range_looks=args.range_looks
+        range_looks=args.range_looks,
+        swath_number=swath_number
     )
     output_zip = make_archive(base_name=product_name, format='zip', base_dir=product_name)
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -334,13 +334,9 @@ def main():
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
     parser.add_argument('--azimuth-looks', type=int, default=4)
     parser.add_argument('--range-looks', type=int, default=20)
-    parser.add_argument('granules', type=str.split, nargs='+')
+    parser.add_argument('granules', type=str, nargs=2)
 
     args = parser.parse_args()
-
-    args.granules = [item for sublist in args.granules for item in sublist]
-    if len(args.granules) != 2:
-        parser.error('Must provide exactly two granules')
 
     configure_root_logger()
     log.debug(' '.join(sys.argv))

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -146,8 +146,8 @@ def make_parameter_file(
 
     Args:
         out_path: path to output the parameter file
-        reference_scene: Reference SLC burst name
-        secondary_scene: Secondary SLC burst name
+        reference_scene: The reference burst name
+        secondary_scene: The secondary burst name
         azimuth_looks: Number of azimuth looks
         range_looks: Number of range looks
         dem_name: Name of the DEM that is use

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -68,6 +68,17 @@ def insar_tops_burst(
     )
     results = asf_search.search(opts=opts)
 
+    fileIDs = [feature['properties']['fileID'] for feature in results.geojson()['features']]
+
+    ref_not_found = reference_scene not in fileIDs
+    sec_not_found = secondary_scene not in fileIDs
+    if ref_not_found and sec_not_found:
+        raise ValueError(f'ASF Search failed to find both {reference_scene} and {secondary_scene}.')
+    elif ref_not_found:
+        raise ValueError(f'ASF Search failed to find {reference_scene}.')
+    elif sec_not_found:
+        raise ValueError(f'ASF Search failed to find {secondary_scene}.')
+
     ref_params = BurstParams(
         results[0].umm['InputGranules'][0].split('-')[0],
         results[0].properties['burst']['subswath'],

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -152,11 +152,16 @@ def make_parameter_file(
 
     parser = etree.XMLParser(encoding='utf-8', recover=True)
 
-    ref_annotation_path = f'{reference_scene}.SAFE/annotation/'
+    ref_tag = reference_scene[-10:-6]
+    sec_tag = secondary_scene[-10:-6]
+    reference_safe = [file for file in os.listdir('.') if file.endswith(f'{ref_tag}.SAFE')][0]
+    secondary_safe = [file for file in os.listdir('.') if file.endswith(f'{sec_tag}.SAFE')][0]
+
+    ref_annotation_path = f'{reference_safe}/annotation/'
     ref_annotation = [file for file in os.listdir(ref_annotation_path) if os.path.isfile(ref_annotation_path + file)][0]
 
-    ref_manifest_xml = etree.parse(f'{reference_scene}.SAFE/manifest.safe', parser)
-    sec_manifest_xml = etree.parse(f'{secondary_scene}.SAFE/manifest.safe', parser)
+    ref_manifest_xml = etree.parse(f'{reference_safe}/manifest.safe', parser)
+    sec_manifest_xml = etree.parse(f'{secondary_safe}/manifest.safe', parser)
     ref_annotation_xml = etree.parse(f'{ref_annotation_path}{ref_annotation}', parser)
     topsProc_xml = etree.parse('topsProc.xml', parser)
     topsApp_xml = etree.parse('topsApp.xml', parser)

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -70,13 +70,13 @@ def insar_tops_burst(
 
     ref_params = BurstParams(
         results[0].umm['InputGranules'][0].split('-')[0],
-        results[0].properties['burst']['swath'],
+        results[0].properties['burst']['subswath'],
         results[0].properties['polarization'],
         results[0].properties['burst']['burstIndex'],
     )
     sec_params = BurstParams(
         results[1].umm['InputGranules'][0].split('-')[0],
-        results[1].properties['burst']['swath'],
+        results[1].properties['burst']['subswath'],
         results[1].properties['polarization'],
         results[1].properties['burst']['burstIndex'],
     )

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -87,5 +87,4 @@ def test_get_region_of_interest(tmp_path, orbit):
 
 
 def test_get_product_name():
-    name = burst.get_product_name('A', 'B', 1, 2, 3, 'VV')
-    assert name == 'A_IW3_VV_1xB_IW3_VV_2'
+    assert burst.get_product_name('A', 'B') == 'AxB'


### PR DESCRIPTION
The current implementation meets the acceptance criteria (except one bug in the comments). It does the least amount of work possible, simply translating the burst scene name into the four legacy parameters (slc name, polarization, subswath, burst index). There's still plenty of refactoring we can do to leverage the metadata we get from CMR and eliminate a lot of existing code in `burst.py`.

Features:
- [x] update the examples in README.md for the new parameter format
- [x] update CHANGELOG.md
- [x] give a useful error message when either granule is not found in CMR
- [x] fix `No such file or directory` exception in `make_parameter_file()`