### PR TITLE
Fix Parameter File

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,8 @@ To run a workflow, simply run `python -m hyp3_isce2 ++process [WORKFLOW_NAME] [W
 
 ```
 python -m hyp3_isce2 ++process insar_tops_burst \
-  --reference-scene S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85 \
-  --secondary-scene S1A_IW_SLC__1SDV_20200616T022252_20200616T022319_033036_03D3A3_5D11 \
-  --swath-number 2 \
-  --polarization VV \
-  --reference-burst-number 7 \
-  --secondary-burst-number 7 \
+  S1_249434_IW1_20230523T170733_VV_8850-BURST \
+  S1_249434_IW1_20230511T170732_VV_07DE-BURST \
   --azimuth-looks 4 \
   --range-looks 20
 ```

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -152,11 +152,16 @@ def make_parameter_file(
 
     parser = etree.XMLParser(encoding='utf-8', recover=True)
 
-    ref_annotation_path = f'{reference_scene}.SAFE/annotation/'
+    ref_tag = reference_scene[-10:-6]
+    sec_tag = secondary_scene[-10:-6]
+    reference_safe = [file for file in os.listdir('.') if file.endswith(f'{ref_tag}.SAFE')][0]
+    secondary_safe = [file for file in os.listdir('.') if file.endswith(f'{sec_tag}.SAFE')][0]
+
+    ref_annotation_path = f'{reference_safe}/annotation/'
     ref_annotation = [file for file in os.listdir(ref_annotation_path) if os.path.isfile(ref_annotation_path + file)][0]
 
-    ref_manifest_xml = etree.parse(f'{reference_scene}.SAFE/manifest.safe', parser)
-    sec_manifest_xml = etree.parse(f'{secondary_scene}.SAFE/manifest.safe', parser)
+    ref_manifest_xml = etree.parse(f'{reference_safe}/manifest.safe', parser)
+    sec_manifest_xml = etree.parse(f'{secondary_safe}/manifest.safe', parser)
     ref_annotation_xml = etree.parse(f'{ref_annotation_path}{ref_annotation}', parser)
     topsProc_xml = etree.parse('topsProc.xml', parser)
     topsApp_xml = etree.parse('topsApp.xml', parser)


### PR DESCRIPTION
The parameter file expected the full SLC name instead of the burst name. 

TODO:
- [x] Find the .SAFE directories with only the burst name provided.

Also adds new example command to the README.