### PR TITLE
implement burst.get_burst_params() to resolve reference/secondary ordering bug

### DIFF
--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -354,8 +354,8 @@ def get_burst_params(scene_name: str) -> BurstParams:
         raise ValueError(f'ASF Search found multiple results for {scene_name}.')
 
     return BurstParams(
-        results[0].umm['InputGranules'][0].split('-')[0],
-        results[0].properties['burst']['subswath'],
-        results[0].properties['polarization'],
-        results[0].properties['burst']['burstIndex'],
+        granule=results[0].umm['InputGranules'][0].split('-')[0],
+        swath=results[0].properties['burst']['subswath'],
+        polarization=results[0].properties['polarization'],
+        burst_number=results[0].properties['burst']['burstIndex'],
     )

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, List, Optional, Tuple, Union
 
+import asf_search
 import isce  # noqa: F401
 import requests
 from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
@@ -337,3 +338,23 @@ def get_product_name(
         The name of the interferogram product.
     """
     return f'{reference_scene}x{secondary_scene}'
+
+
+def get_burst_params(scene_name: str) -> BurstParams:
+    opts = asf_search.ASFSearchOptions(
+        host='cmr.uat.earthdata.nasa.gov',
+        product_list=[scene_name],
+    )
+    results = asf_search.search(opts=opts)
+
+    if len(results) == 0:
+        raise ValueError(f'ASF Search failed to find {scene_name}.')
+    if len(results) > 1:
+        raise ValueError(f'ASF Search found multiple results for {scene_name}.')
+
+    return BurstParams(
+        results[0].umm['InputGranules'][0].split('-')[0],
+        results[0].properties['burst']['subswath'],
+        results[0].properties['polarization'],
+        results[0].properties['burst']['burstIndex'],
+    )

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -88,3 +88,19 @@ def test_get_region_of_interest(tmp_path, orbit):
 
 def test_get_product_name():
     assert burst.get_product_name('A', 'B') == 'AxB'
+
+
+def test_get_burst_params():
+    assert burst.get_burst_params('S1_346041_IW3_20230526T190843_VV_08F8-BURST') == burst.BurstParams(
+        'S1A_IW_SLC__1SDV_20230526T190821_20230526T190847_048709_05DBA8_08F8', 'IW3', 'VV', 8,
+    )
+
+    assert burst.get_burst_params('S1_308695_EW5_20230526T143259_HH_1B3B-BURST') == burst.BurstParams(
+        'S1A_EW_SLC__1SDH_20230526T143200_20230526T143303_048706_05DB92_1B3B', 'EW5', 'HH', 19,
+    )
+
+    with pytest.raises(ValueError):
+        burst.get_burst_params('this burst does not exist')
+
+    with pytest.raises(ValueError):
+        burst.get_burst_params('there are multiple copies of this burst')

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -93,16 +93,16 @@ def test_get_product_name():
 
 
 def mock_asf_search_results(
+        slc_name: str,
         subswath: str,
-        burst_index: int,
         polarization: str,
-        slc_name: str) -> asf_search.ASFSearchResults:
+        burst_index: int) -> asf_search.ASFSearchResults:
     product = asf_search.ASFProduct()
+    product.umm = {'InputGranules': [slc_name]}
     product.properties.update({
         'burst': {'subswath': subswath, 'burstIndex': burst_index},
         'polarization': polarization,
     })
-    product.umm = {'InputGranules': [slc_name]}
     results = asf_search.ASFSearchResults([product])
     results.searchComplete = True
     return results

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -111,13 +111,16 @@ def mock_asf_search_results(
 def test_get_burst_params_08F8():
     with patch.object(burst, 'search_cmr_uat') as mock_search_cmr_uat:
         mock_search_cmr_uat.return_value = mock_asf_search_results(
+            slc_name='S1A_IW_SLC__1SDV_20230526T190821_20230526T190847_048709_05DBA8_08F8-SLC',
             subswath='IW3',
-            burst_index=8,
             polarization='VV',
-            slc_name='S1A_IW_SLC__1SDV_20230526T190821_20230526T190847_048709_05DBA8_08F8-SLC'
+            burst_index=8,
         )
         assert burst.get_burst_params('S1_346041_IW3_20230526T190843_VV_08F8-BURST') == burst.BurstParams(
-            'S1A_IW_SLC__1SDV_20230526T190821_20230526T190847_048709_05DBA8_08F8', 'IW3', 'VV', 8,
+            granule='S1A_IW_SLC__1SDV_20230526T190821_20230526T190847_048709_05DBA8_08F8',
+            swath='IW3',
+            polarization='VV',
+            burst_number=8,
         )
         mock_search_cmr_uat.assert_called_once_with('S1_346041_IW3_20230526T190843_VV_08F8-BURST')
 
@@ -125,13 +128,16 @@ def test_get_burst_params_08F8():
 def test_get_burst_params_1B3B():
     with patch.object(burst, 'search_cmr_uat') as mock_search_cmr_uat:
         mock_search_cmr_uat.return_value = mock_asf_search_results(
-            subswath='EW5',
-            burst_index=19,
-            polarization='HH',
             slc_name='S1A_EW_SLC__1SDH_20230526T143200_20230526T143303_048706_05DB92_1B3B-SLC',
+            subswath='EW5',
+            polarization='HH',
+            burst_index=19,
         )
         assert burst.get_burst_params('S1_308695_EW5_20230526T143259_HH_1B3B-BURST') == burst.BurstParams(
-            'S1A_EW_SLC__1SDH_20230526T143200_20230526T143303_048706_05DB92_1B3B', 'EW5', 'HH', 19,
+            granule='S1A_EW_SLC__1SDH_20230526T143200_20230526T143303_048706_05DB92_1B3B',
+            swath='EW5',
+            polarization='HH',
+            burst_number=19,
         )
         mock_search_cmr_uat.assert_called_with('S1_308695_EW5_20230526T143259_HH_1B3B-BURST')
 


### PR DESCRIPTION
TODO:
- [x] mock search requests in `test_get_burst_params()`