### PR TITLE
Switch to use dem.crop as dem source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Replace `--range-looks` and `--azimuth-looks` options with a single `--looks` option for `insar_tops` and `insar_tops_burst` workflows
 * `insar_tops_burst` workflow now always uses the oldest granule as the reference.
 
+### Fixes
+* Incomplete DEM generation issue by switching to using `merged/dem.crop` as the source
+
 ## [0.3.0]
 ### Added
 * `insar_tops` workflow for processing of full Sentinel-1 SLCs.

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -130,6 +130,8 @@ def insar_tops_burst(
     copyfile('merged/z.rdr.full.xml', 'merged/z.rdr.full.vrt.xml')
     topsapp.run_topsapp_burst(start='geocode', end='geocode', config_xml=config_path)
 
+    return Path('merged')
+
 
 def make_parameter_file(
     out_path: Path,
@@ -369,7 +371,7 @@ def main():
     swath_number = int(reference_scene[12])
     range_looks, azimuth_looks = [int(looks) for looks in args.looks.split('x')]
 
-    insar_tops_burst(
+    isce_output_dir = insar_tops_burst(
         reference_scene=reference_scene,
         secondary_scene=secondary_scene,
         azimuth_looks=azimuth_looks,
@@ -380,7 +382,6 @@ def main():
     log.info('ISCE2 TopsApp run completed successfully')
     product_name = get_product_name(reference_scene, secondary_scene)
 
-    isce_output_dir = Path('merged')
     product_dir = Path(product_name)
     product_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -369,13 +369,13 @@ def main():
     swath_number = int(reference_scene[12])
     range_looks, azimuth_looks = [int(looks) for looks in args.looks.split('x')]
 
-    # insar_tops_burst(
-    #     reference_scene=reference_scene,
-    #     secondary_scene=secondary_scene,
-    #     azimuth_looks=azimuth_looks,
-    #     range_looks=range_looks,
-    #     swath_number=swath_number
-    # )
+    insar_tops_burst(
+        reference_scene=reference_scene,
+        secondary_scene=secondary_scene,
+        azimuth_looks=azimuth_looks,
+        range_looks=range_looks,
+        swath_number=swath_number
+    )
 
     log.info('ISCE2 TopsApp run completed successfully')
     product_name = get_product_name(reference_scene, secondary_scene)

--- a/src/hyp3_isce2/topsapp.py
+++ b/src/hyp3_isce2/topsapp.py
@@ -35,7 +35,6 @@ TOPSAPP_GEOCODE_LIST = [
     'merged/phsig.cor',
     'merged/filt_topophase.unw',
     'merged/los.rdr',
-    'merged/z.rdr.full.vrt',
     'merged/filt_topophase.flat',
     'merged/topophase.cor',
     'merged/filt_topophase.unw.conncomp',


### PR DESCRIPTION
Geocoding `z.rdr.full` led to errors in the output DEM. This PR switches to using `dem.crop` by add a geotransform to it.