### PR TITLE
Clean up burst readme generation, fix ref/sec scene order

### DIFF
--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -337,6 +337,8 @@ def get_product_name(
     Returns:
         The name of the interferogram product.
     """
+    # If this changes, we will also need to update the burst product README template,
+    # which documents this naming convention.
     return f'{reference_scene}x{secondary_scene}'
 
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -111,6 +111,41 @@ def insar_tops_burst(
     return Path('merged')
 
 
+def make_readme(
+        product_dir: Path,
+        product_name: str,
+        reference_scene: str,
+        secondary_scene: str,
+        range_looks: int,
+        azimuth_looks: int) -> None:
+
+    wrapped_phase_path = product_dir / f'{product_name}_wrapped_phase.tif'
+    info = gdal.Info(str(wrapped_phase_path), format='json')
+    secondary_granule_datetime_str = secondary_scene.split("_")[3]
+
+    payload = {
+        'processing_date': datetime.now(timezone.utc),
+        'plugin_name': hyp3_isce2.__name__,
+        'plugin_version': hyp3_isce2.__version__,
+        'processor_name': isce.__name__.upper(),
+        'processor_version': isce.__version__,
+        'projection': util.get_projection(info['coordinateSystem']['wkt']),
+        'pixel_spacing': info['geoTransform'][1],
+        'reference_burst_name': reference_scene,
+        'secondary_burst_name': secondary_scene,
+        'range_looks': range_looks,
+        'azimuth_looks': azimuth_looks,
+        'secondary_granule_date': datetime.strptime(secondary_granule_datetime_str, '%Y%m%dT%H%M%S'),
+        'dem_name': 'GLO-30',
+        'dem_pixel_spacing': '30 m',
+    }
+    content = util.render_template('insar_burst/readme.md.txt.j2', payload)
+
+    output_file = product_dir / f'{product_name}_README.md.txt'
+    with open(output_file, 'w') as f:
+        f.write(content)
+
+
 def make_parameter_file(
     out_path: Path,
     reference_scene: str,
@@ -365,37 +400,14 @@ def main():
 
     translate_outputs(isce_output_dir, product_name)
 
-    payload = {}
-    payload['product_dir'] = Path(product_name)
-    payload['reference_burst_name'] = args.granules[0]
-    payload['secondary_burst_name'] = args.granules[1]
-    payload['processing_date'] = datetime.now(timezone.utc)
-    payload['range_looks'] = range_looks
-    payload['azimuth_looks'] = azimuth_looks
-    payload['dem_name'] = 'GLO-30'
-    payload['dem_pixel_spacing'] = '30 m'
-    payload['plugin_name'] = hyp3_isce2.__name__
-    payload['plugin_version'] = hyp3_isce2.__version__
-    payload['processor_name'] = isce.__name__.upper()
-    payload['processor_version'] = isce.__version__
-
-    secondary_granule_datetime_str = args.granules[1].split("_")[3]
-    payload['secondary_granule'] = datetime.strptime(secondary_granule_datetime_str, '%Y%m%dT%H%M%S')
-
-    payload['water_mask_applied'] = False
-
-    reference_file = product_dir / f'{product_name}_wrapped_phase.tif'
-    info = gdal.Info(str(reference_file), format='json')
-    payload['reference_file'] = reference_file.name
-    payload['pixel_spacing'] = info['geoTransform'][1]
-    payload['projection'] = util.get_projection(info['coordinateSystem']['wkt'])
-
-    content = util.render_template('insar_burst/readme.md.txt.j2', payload)
-
-    output_file = product_dir / f'{product_dir}_README.md.txt'
-    with open(output_file, 'w') as f:
-        f.write(content)
-
+    make_readme(
+        product_dir=product_dir,
+        product_name=product_name,
+        reference_scene=reference_scene,
+        secondary_scene=secondary_scene,
+        range_looks=range_looks,
+        azimuth_looks=azimuth_looks
+    )
     make_parameter_file(
         Path(f'{product_name}/{product_name}.txt'),
         reference_scene=reference_scene,

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -19,6 +19,7 @@ from lxml import etree
 from osgeo import gdal
 
 import hyp3_isce2
+import hyp3_isce2.metadata.util
 from hyp3_isce2 import topsapp
 from hyp3_isce2.burst import (
     download_bursts,
@@ -29,7 +30,6 @@ from hyp3_isce2.burst import (
 )
 from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.logging import configure_root_logger
-from hyp3_isce2.metadata import util
 from hyp3_isce2.s1_auxcal import download_aux_cal
 from hyp3_isce2.utils import make_browse_image, oldest_granule_first, utm_from_lon_lat
 
@@ -129,7 +129,7 @@ def make_readme(
         'plugin_version': hyp3_isce2.__version__,
         'processor_name': isce.__name__.upper(),
         'processor_version': isce.__version__,
-        'projection': util.get_projection(info['coordinateSystem']['wkt']),
+        'projection': hyp3_isce2.metadata.util.get_projection(info['coordinateSystem']['wkt']),
         'pixel_spacing': info['geoTransform'][1],
         'reference_burst_name': reference_scene,
         'secondary_burst_name': secondary_scene,
@@ -139,7 +139,7 @@ def make_readme(
         'dem_name': 'GLO-30',
         'dem_pixel_spacing': '30 m',
     }
-    content = util.render_template('insar_burst/readme.md.txt.j2', payload)
+    content = hyp3_isce2.metadata.util.render_template('insar_burst/readme.md.txt.j2', payload)
 
     output_file = product_dir / f'{product_name}_README.md.txt'
     with open(output_file, 'w') as f:

--- a/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
+++ b/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
@@ -72,15 +72,15 @@ of {{ pixel_spacing|int }} m.
 When using this data as an image in a publication such as journal papers, articles, presentations, posters,
 and websites, please include the following credit with the image (portions in square brackets are optional):
 
-    [Sentinel-1 Burst InSAR product processed by ]ASF DAAC HyP3 {{ processing_date.year }}[ using {{processor_name}}
-     software]. Contains modified Copernicus Sentinel data {{ secondary_granule.year }}, processed by ESA.
+    [Sentinel-1 Burst InSAR product processed by ]ASF DAAC HyP3 {{ processing_date.year }}[ using {{ processor_name }}
+     software]. Contains modified Copernicus Sentinel data {{ secondary_granule_date.year }}, processed by ESA.
 
 When using this data in a manuscript and/or crediting datasets used for analysis, an acknowledgement including the
 software versions may be appropriate:
 
     ASF DAAC HyP3 {{ processing_date.year }} using the {{ plugin_name }} plugin version {{ plugin_version }} running
     {{ processor_name }} release {{ processor_version }}. Contains modified Copernicus Sentinel data
-    {{ secondary_granule.year }}, processed by ESA.
+    {{ secondary_granule_date.year }}, processed by ESA.
 
 To reference HyP3 in manuscripts, cite our documentation available at https://github.com/ASFHyP3/hyp3-docs:
 

--- a/src/hyp3_isce2/metadata/util.py
+++ b/src/hyp3_isce2/metadata/util.py
@@ -1,10 +1,3 @@
-import re
-from base64 import b64encode
-from io import BytesIO
-from pathlib import Path
-from typing import Dict, Tuple
-
-from PIL import Image
 from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
 from osgeo import osr
 
@@ -32,39 +25,3 @@ def get_projection(srs_wkt) -> str:
     srs = osr.SpatialReference()
     srs.ImportFromWkt(srs_wkt)
     return srs.GetAttrValue('projcs')
-
-
-def get_granule_type(granule_name) -> Dict[str, str]:
-    granule_type = granule_name[7:10]
-    if granule_type == 'SLC':
-        return {'granule_type': 'SLC', 'granule_description': 'Single Look Complex'}
-    if granule_type == 'GRD':
-        return {'granule_type': 'GRD', 'granule_description': 'Ground Range Detected'}
-    raise NotImplementedError(f'Unknown granule type: {granule_name}')
-
-
-def get_polarizations(product_polarization):
-    mapping = {
-        'SH': ('HH',),
-        'SV': ('VV',),
-        'DH': ('HH', 'HV'),
-        'DV': ('VV', 'VH'),
-    }
-    return mapping[product_polarization]
-
-
-def strip_polarization(file_name: str) -> str:
-    return re.sub(r'_(VV|VH|HH|HV)', '', file_name)
-
-
-def get_thumbnail_encoded_string(browse_file: Path, size: Tuple[int, int] = (200, 200)) -> str:
-    if not browse_file.exists():
-        return ''
-
-    image = Image.open(browse_file)
-    image = image.convert('RGB')
-    image.thumbnail(size)
-
-    data = BytesIO()
-    image.save(data, format='JPEG')
-    return b64encode(data.getvalue()).decode()


### PR DESCRIPTION
* Move all of the code for generating the burst README into a separate helper function
* Delete unused functions from the `metadata.util` module
* Fix a bug in which the burst README does not preserve reference/secondary granule name order
   * As seen in this test job: https://hyp3-enterprise-test.asf.alaska.edu/jobs/9140150a-861e-4513-bb3a-ac04cc5860f1

TODO:

- [x] Run the plugin locally to confirm the README generation still works.