### PR TITLE
fix reference to single browse image in insar_tops_burst readme

### DIFF
--- a/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
+++ b/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
@@ -272,7 +272,7 @@ a value of 1. The water mask is stored as an 8-bit unsigned integer GeoTIFF file
 package.
 
 Users can choose to apply the water mask to output products, which affects the wrapped interferogram,
-the unwrapped interferogram, and the browse images. It returns NoData values over the areas covered by the water mask
+the unwrapped interferogram, and the browse image. It returns NoData values over the areas covered by the water mask
 in these output images. This product {{ "has" if apply_water_mask else "has not" }} had the water mask applied.
 
 The water mask is generated using the Global Self-consistent, Hierarchical, High-resolution Geography Database (GSHHG)


### PR DESCRIPTION
We only have a single browse image for burst insar products at the moment, created from the unwrapped phase geotiff.