### PR TITLE
Updated Naming Convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0]
+### Changed
+* The naming convention for the burst products has been updated.
+
 ## [0.6.2]
 ### Changed
 * The geocoding DEM is now resampled to ~20m in the case of 5x1 looks.

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -350,7 +350,7 @@ def get_product_name(
     reference_date = reference_split[3]
     secondary_date = secondary_split[3]
     polarization = reference_split[4]
-    pixel_spacing = "INT" + str(pixel_spacing)
+    pixel_spacing = "INT" + str(int(pixel_spacing))
     product_id = token_hex(2).upper()
 
     return '_'.join([

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -347,10 +347,11 @@ def get_product_name(
     platform = reference_split[0]
     burst_id = reference_split[1]
     image_plus_swath = reference_split[2]
-    reference_date = reference_split[3]
-    secondary_date = secondary_split[3]
+    reference_date = reference_split[3][0:8]
+    secondary_date = secondary_split[3][0:8]
     polarization = reference_split[4]
-    pixel_spacing = "INT" + str(int(pixel_spacing))
+    product_type = "INT"
+    pixel_spacing = str(int(pixel_spacing))
     product_id = token_hex(2).upper()
 
     return '_'.join([
@@ -360,7 +361,7 @@ def get_product_name(
         reference_date,
         secondary_date,
         polarization,
-        pixel_spacing,
+        product_type + pixel_spacing,
         product_id
     ])
 

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -332,26 +332,15 @@ def get_product_name(
 ) -> str:
     """Get the name of the interferogram product.
 
-    Format is S1_tttttt_iiw_aaaaaaaa_gggggggg_pp_INTzz_ssss
-        t: burst id
-        i: image mode (IW or EW)
-        w: swath number
-        a: reference burst date
-        g: secondary burst date
-        p: polariztion
-        z: pixel spacing
-        s: ASF product id
-
     Args:
         reference_scene: The reference burst name.
         secondary_scene: The secondary burst name.
         pixel_spacing: The spacing of the pixels in the output image.
-        
+
     Returns:
         The name of the interferogram product.
     """
-    # If this changes, we will also need to update the burst product README template,
-    # which documents this naming convention.
+
     reference_split = reference_scene.split('_')
     secondary_split = secondary_scene.split('_')
 

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -350,7 +350,7 @@ def get_product_name(
     reference_date = reference_split[3][0:8]
     secondary_date = secondary_split[3][0:8]
     polarization = reference_split[4]
-    product_type = "INT"
+    product_type = 'INT'
     pixel_spacing = str(int(pixel_spacing))
     product_id = token_hex(2).upper()
 

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -327,19 +327,52 @@ def download_bursts(param_list: Iterator[BurstParams]) -> List[BurstMetadata]:
 def get_product_name(
     reference_scene: str,
     secondary_scene: str,
+    pixel_spacing: int
 ) -> str:
     """Get the name of the interferogram product.
+
+    Format is S1_tttttt_iiw_aaaaaaaa_gggggggg_pp_INTzz_ssss
+        t: burst id
+        i: image mode (IW or EW)
+        w: swath number
+        a: reference burst date
+        g: secondary burst date
+        p: polariztion
+        z: pixel spacing
+        s: ASF product id
 
     Args:
         reference_scene: The reference burst name.
         secondary_scene: The secondary burst name.
-
+        pixel_spacing: The spacing of the pixels in the output image.
+        
     Returns:
         The name of the interferogram product.
     """
     # If this changes, we will also need to update the burst product README template,
     # which documents this naming convention.
-    return f'{reference_scene}x{secondary_scene}'
+    reference_split = reference_scene.split('_')
+    secondary_split = secondary_scene.split('_')
+
+    platform = reference_split[0]
+    burst_id = reference_split[1]
+    image_plus_swath = reference_split[2]
+    reference_date = reference_split[3]
+    secondary_date = secondary_split[3]
+    polarization = reference_split[4]
+    pixel_spacing = "INT" + str(pixel_spacing)
+    product_id = reference_split[5][0:4]
+
+    return '_'.join([
+        platform,
+        burst_id,
+        image_plus_swath,
+        reference_date,
+        secondary_date,
+        polarization,
+        pixel_spacing,
+        product_id
+    ])
 
 
 def get_burst_params(scene_name: str) -> BurstParams:

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -6,6 +6,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
+from secrets import token_hex
 from typing import Iterator, List, Optional, Tuple, Union
 
 import asf_search
@@ -361,7 +362,7 @@ def get_product_name(
     secondary_date = secondary_split[3]
     polarization = reference_split[4]
     pixel_spacing = "INT" + str(pixel_spacing)
-    product_id = reference_split[5][0:4]
+    product_id = token_hex(2).upper()
 
     return '_'.join([
         platform,

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -152,6 +152,7 @@ def make_readme(
         'processor_version': isce.__version__,
         'projection': hyp3_isce2.metadata.util.get_projection(info['coordinateSystem']['wkt']),
         'pixel_spacing': info['geoTransform'][1],
+        'product_name': product_name,
         'reference_burst_name': reference_scene,
         'secondary_burst_name': secondary_scene,
         'range_looks': range_looks,

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -427,12 +427,12 @@ def main():
     )
 
     log.info('ISCE2 TopsApp run completed successfully')
-    product_name = get_product_name(reference_scene, secondary_scene)
+    pixel_size = get_pixel_size(args.looks)
+    product_name = get_product_name(reference_scene, secondary_scene, pixel_spacing=int(pixel_size))
 
     product_dir = Path(product_name)
     product_dir.mkdir(parents=True, exist_ok=True)
 
-    pixel_size = get_pixel_size(args.looks)
     translate_outputs(isce_output_dir, product_name, pixel_size=pixel_size)
 
     unwrapped_phase = f'{product_name}/{product_name}_unw_phase.tif'

--- a/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
+++ b/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
@@ -19,13 +19,11 @@ The source bursts for this InSAR product are:
 
 Processing Date/Time: {{ processing_date.isoformat(timespec='seconds') }}
 
-The product directory is named <reference_burst_name>x<secondary_burst_name>
+The directory name for this product is: {{ product_name }}
 
-The directory name for this product is: {{ reference_burst_name }}x{{ secondary_burst_name }}.
+The output directory uses the following naming convention:
 
-The reference_burst_name and secondary_burst_name use the following naming conventions:
-
-S1_bbbbbb_xxn_yyyymmddThhmmss_pp_cccc-BURST
+S1_bbbbbb_xxn_yyyymmddThhmmss_yyyymmddThhmmss_pp_INTzz_cccc
 
 bbbbbb: Relative burst ID values assigned by ESA. Each value identifies a consistent burst footprint; relative burst
         ID values differ from one subswath to the next.
@@ -35,7 +33,7 @@ xxn: Three character combination that represents the acquisition mode and subswa
         (1-3 for IW, 1-5 for EW). IW mode indicates Interferometric Wideswath, which acquires a 250 km swath composed
         of three subswaths. EW mode indicates Extra-Wide Swath, which acquires a 400 km swath composed of 5 subswaths.
 
-yyyymmddThhmmss: ISO date and time of acquisition.
+yyyymmddThhmmss: ISO date and time of acquisition of the reference and secondary images, respectively.
 
 pp: Two character combination that represents the mode of radar orientation (polarization) for both signal
         transmission and reception. The first position represents the transmit orientation mode and the second
@@ -45,6 +43,8 @@ pp: Two character combination that represents the mode of radar orientation (pol
     HV: Horizontal Transmit - Vertical Receive
     VH: Vertical Transmit - Horizontal Receive
     VV: Vertical Transmit - Vertical Receive
+
+zz: The pixel spacing of the output image.
 
 cccc: 4-character "Product Unique Identifier" from the SLC filename.
 

--- a/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
+++ b/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
@@ -23,7 +23,7 @@ The directory name for this product is: {{ product_name }}
 
 The output directory uses the following naming convention:
 
-S1_bbbbbb_xxn_yyyymmddThhmmss_yyyymmddThhmmss_pp_INTzz_cccc
+S1_bbbbbb_xxn_yyyymmdd_yyyymmdd_pp_INTzz_cccc
 
 bbbbbb: Relative burst ID values assigned by ESA. Each value identifies a consistent burst footprint; relative burst
         ID values differ from one subswath to the next.
@@ -33,7 +33,7 @@ xxn: Three character combination that represents the acquisition mode and subswa
         (1-3 for IW, 1-5 for EW). IW mode indicates Interferometric Wideswath, which acquires a 250 km swath composed
         of three subswaths. EW mode indicates Extra-Wide Swath, which acquires a 400 km swath composed of 5 subswaths.
 
-yyyymmddThhmmss: ISO date and time of acquisition of the reference and secondary images, respectively.
+yyyymmdd: Date of acquisition of the reference and secondary images, respectively.
 
 pp: Two character combination that represents the mode of radar orientation (polarization) for both signal
         transmission and reception. The first position represents the transmit orientation mode and the second
@@ -43,6 +43,8 @@ pp: Two character combination that represents the mode of radar orientation (pol
     HV: Horizontal Transmit - Vertical Receive
     VH: Vertical Transmit - Horizontal Receive
     VV: Vertical Transmit - Vertical Receive
+
+INT: The product type (always INT for InSAR).
 
 zz: The pixel spacing of the output image.
 

--- a/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
+++ b/src/hyp3_isce2/metadata/templates/insar_burst/readme.md.txt.j2
@@ -46,7 +46,7 @@ pp: Two character combination that represents the mode of radar orientation (pol
 
 zz: The pixel spacing of the output image.
 
-cccc: 4-character "Product Unique Identifier" from the SLC filename.
+cccc: 4-character unique product identifier.
 
 Files contained in the product directory are named using the directory name followed by a tag indicating the file type.
 

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from re import match
 from unittest.mock import patch
 
 import asf_search
@@ -89,7 +90,18 @@ def test_get_region_of_interest(tmp_path, orbit):
 
 
 def test_get_product_name():
-    assert burst.get_product_name('A', 'B') == 'AxB'
+
+    reference_name = "S1_136231_IW2_20200604T022312_VV_7C85-BURST"
+    secondary_name = "S1_136231_IW2_20200616T022313_VV_5D11-BURST"
+
+    name_20m = burst.get_product_name(reference_name, secondary_name, pixel_spacing = 20.0)
+    name_80m = burst.get_product_name(reference_name, secondary_name, pixel_spacing = 80)
+
+    assert match("[A-F0-9]{4}", name_20m[-4:]) != None
+    assert match("[A-F0-9]{4}", name_80m[-4:]) != None
+
+    assert name_20m.startswith('S1_136231_IW2_20200604T022312_20200616T022313_VV_INT20')
+    assert name_80m.startswith('S1_136231_IW2_20200604T022312_20200616T022313_VV_INT80')
 
 
 def mock_asf_search_results(

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -100,8 +100,8 @@ def test_get_product_name():
     assert match("[A-F0-9]{4}", name_20m[-4:]) is not None
     assert match("[A-F0-9]{4}", name_80m[-4:]) is not None
 
-    assert name_20m.startswith('S1_136231_IW2_20200604T022312_20200616T022313_VV_INT20')
-    assert name_80m.startswith('S1_136231_IW2_20200604T022312_20200616T022313_VV_INT80')
+    assert name_20m.startswith('S1_136231_IW2_20200604_20200616_VV_INT20')
+    assert name_80m.startswith('S1_136231_IW2_20200604_20200616_VV_INT80')
 
 
 def mock_asf_search_results(

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -94,11 +94,11 @@ def test_get_product_name():
     reference_name = "S1_136231_IW2_20200604T022312_VV_7C85-BURST"
     secondary_name = "S1_136231_IW2_20200616T022313_VV_5D11-BURST"
 
-    name_20m = burst.get_product_name(reference_name, secondary_name, pixel_spacing = 20.0)
-    name_80m = burst.get_product_name(reference_name, secondary_name, pixel_spacing = 80)
+    name_20m = burst.get_product_name(reference_name, secondary_name, pixel_spacing=20.0)
+    name_80m = burst.get_product_name(reference_name, secondary_name, pixel_spacing=80)
 
-    assert match("[A-F0-9]{4}", name_20m[-4:]) != None
-    assert match("[A-F0-9]{4}", name_80m[-4:]) != None
+    assert match("[A-F0-9]{4}", name_20m[-4:]) is not None
+    assert match("[A-F0-9]{4}", name_80m[-4:]) is not None
 
     assert name_20m.startswith('S1_136231_IW2_20200604T022312_20200616T022313_VV_INT20')
     assert name_80m.startswith('S1_136231_IW2_20200604T022312_20200616T022313_VV_INT80')


### PR DESCRIPTION
New product name format:

S1_tttttt_iiw_yyyymmddThhmmss_yyyymmddThhmmss_pp_INTzz_ssss
  
  tttttt: burst id
  ii: image mode (IW or EW)
  w: swath number
  yyyymmddThhmmss: reference burst date
  yyyymmddThhmmss: secondary burst date
  pp: polariztion
  zz: pixel spacing
  ssss: ASF product id