### PR TITLE
Fix call to `imageMath.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1]
+### Fixed
+* Fixed a typo in the call to `imageMath.py`.
+* `imageMath.py` is now called via `subprocess.run` rather than `os.system`.
+
 ## [0.8.0]
 ### Added
 * Functions for resampling geographic image to radar coordinates, copying ISCE2 images, and performing ISCE2 image math to utils.py.

--- a/src/hyp3_isce2/utils.py
+++ b/src/hyp3_isce2/utils.py
@@ -1,5 +1,5 @@
-import os
 import shutil
+import subprocess
 
 import isce  # noqa
 import isceobj

--- a/src/hyp3_isce2/utils.py
+++ b/src/hyp3_isce2/utils.py
@@ -215,13 +215,13 @@ def isce2_copy(in_path: str, out_path: str):
 
 
 def image_math(image_a_path: str, image_b_path: str, out_path: str, expression: str):
-    """Run ISCE2's ImageMath.py on two images.
+    """Run ISCE2's imageMath.py on two images.
 
     Args:
         image_a_path: The path to the first image (not the xml).
         image_b_path: The path to the second image (not the xml).
         out_path: The path to the output image.
-        expression: The expression to pass to ImageMath.py.
+        expression: The expression to pass to imageMath.py.
     """
-    cmd = ['ImageMath.py', '-e', expression, f'--a={image_a_path}', f'--b={image_b_path}', '-o', out_path]
+    cmd = ['imageMath.py', '-e', expression, f'--a={image_a_path}', f'--b={image_b_path}', '-o', out_path]
     subprocess.run(cmd, check=True)

--- a/src/hyp3_isce2/utils.py
+++ b/src/hyp3_isce2/utils.py
@@ -223,7 +223,5 @@ def image_math(image_a_path: str, image_b_path: str, out_path: str, expression: 
         out_path: The path to the output image.
         expression: The expression to pass to ImageMath.py.
     """
-    cmd = f"ImageMath.py -e '{expression}' --a={image_a_path} --b={image_b_path} -o {out_path}"
-    status = os.system(cmd)
-    if status != 0:
-        raise Exception('error when running:\n{}\n'.format(cmd))
+    cmd = ['ImageMath.py', '-e', expression, f'--a={image_a_path}', f'--b={image_b_path}', '-o', out_path]
+    subprocess.run(cmd, check=True)


### PR DESCRIPTION
Currently, if I build the conda environment locally and run the example command from the README:

```
python -m hyp3_isce2 ++process insar_tops_burst \
  S1_136231_IW2_20200604T022312_VV_7C85-BURST \
  S1_136231_IW2_20200616T022313_VV_5D11-BURST \
  --looks 20x4 \
  --apply-water-mask True
```

It fails with: `sh: 1: ImageMath.py: not found`.  Using `subprocess` instead of `os.system` should resolve the path issue.

Edit: Nope, still fails with the same problem: `FileNotFoundError: [Errno 2] No such file or directory: 'ImageMath.py'`

Edit 2: It was a typo, should be `imageMath.py`.