### PR TITLE
Refactor ISCE2 applications path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2]
+### Changed
+* All the special ISCE2 environment variable, python path, and system path handling has been moved to `hyp3_isce2.__init__.py` to ensure it's always done before using any object in this package.
+* All [subprocess](https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module) calls use `subprocess.run`, as recommended.
+
 ## [0.8.1]
 ### Fixed
 * Fixed a typo in the call to `imageMath.py`.

--- a/src/hyp3_isce2/__init__.py
+++ b/src/hyp3_isce2/__init__.py
@@ -1,6 +1,17 @@
 """HyP3 plugin for ISCE2 processing"""
-
+import os
 from importlib.metadata import version
+from pathlib import Path
+
+# Ensures all ISCE2 paths and environment variables are set when using this module, see:
+# https://github.com/isce-framework/isce2/blob/main/__init__.py#L41-L50
+import isce  # noqa: F401
+# ISCE2 also needs its applications to be on the system path, even though they say it's only "for convenience", see:
+# https://github.com/isce-framework/isce2#setup-your-environment
+ISCE_APPLICATIONS = str(Path(os.environ['ISCE_HOME']) / 'applications')
+if ISCE_APPLICATIONS not in (PATH := os.environ['PATH'].split(os.pathsep)):
+    os.environ['PATH'] = os.pathsep.join([ISCE_APPLICATIONS] + PATH)
+
 
 __version__ = version(__name__)
 

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -10,7 +10,6 @@ from secrets import token_hex
 from typing import Iterator, List, Optional, Tuple, Union
 
 import asf_search
-import isce  # noqa: F401
 import requests
 from isceobj.Sensor.TOPS.Sentinel1 import Sentinel1
 from lxml import etree

--- a/src/hyp3_isce2/dem.py
+++ b/src/hyp3_isce2/dem.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import site
 import subprocess
 from pathlib import Path
 
@@ -40,9 +39,8 @@ def tag_dem_xml_as_ellipsoidal(dem_path: Path) -> str:
 
 
 def fix_image_xml(xml_path: str) -> None:
-    fix_image_path = Path(site.getsitepackages()[0]) / 'isce' / 'applications' / 'fixImageXml.py'
-    fix_cmd = ' '.join([str(fix_image_path), '-i', xml_path, '--full'])
-    subprocess.check_call(fix_cmd, shell=True)
+    cmd = ['fixImageXml.py', '-i', xml_path, '--full']
+    subprocess.run(cmd, check=True)
 
 
 def buffer_extent(extent: list, buffer: float) -> list:

--- a/src/hyp3_isce2/insar_stripmap.py
+++ b/src/hyp3_isce2/insar_stripmap.py
@@ -7,7 +7,6 @@ import glob
 import logging
 import os
 import shutil
-import site
 import sys
 import zipfile
 from pathlib import Path
@@ -22,12 +21,6 @@ from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.logging import configure_root_logger
 
 log = logging.getLogger(__name__)
-
-# ISCE needs its applications to be on the system path.
-# See https://github.com/isce-framework/isce2#setup-your-environment
-ISCE_APPLICATIONS = Path(site.getsitepackages()[0]) / 'isce' / 'applications'
-if str(ISCE_APPLICATIONS) not in os.environ['PATH'].split(os.pathsep):
-    os.environ['PATH'] = str(ISCE_APPLICATIONS) + os.pathsep + os.environ['PATH']
 
 
 def insar_stripmap(user: str, password: str, reference_scene: str, secondary_scene: str) -> Path:

--- a/src/hyp3_isce2/insar_tops.py
+++ b/src/hyp3_isce2/insar_tops.py
@@ -2,8 +2,6 @@
 
 import argparse
 import logging
-import os
-import site
 import sys
 from pathlib import Path
 from shutil import copyfile, make_archive
@@ -19,12 +17,6 @@ from hyp3_isce2.s1_auxcal import download_aux_cal
 
 
 log = logging.getLogger(__name__)
-
-# ISCE needs its applications to be on the system path.
-# See https://github.com/isce-framework/isce2#setup-your-environment
-ISCE_APPLICATIONS = Path(site.getsitepackages()[0]) / 'isce' / 'applications'
-if str(ISCE_APPLICATIONS) not in os.environ['PATH'].split(os.pathsep):
-    os.environ['PATH'] = str(ISCE_APPLICATIONS) + os.pathsep + os.environ['PATH']
 
 
 def insar_tops(

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -339,7 +339,7 @@ def translate_outputs(isce_output_dir: Path, product_name: str, pixel_size: floa
         '--calc angle(A) --type Float32 --format GTiff --NoDataValue=0 '
         '--creation-option TILED=YES --creation-option COMPRESS=LZW --creation-option NUM_THREADS=ALL_CPUS'
     )
-    subprocess.check_call(cmd.split(' '))
+    subprocess.run(cmd.split(' '), check=True)
 
     ds = gdal.Open(str(isce_output_dir / 'los.rdr.geo'), gdal.GA_Update)
     ds.GetRasterBand(1).SetNoDataValue(0)
@@ -358,7 +358,7 @@ def translate_outputs(isce_output_dir: Path, product_name: str, pixel_size: floa
         '--calc (90-A)*pi/180 --type Float32 --format GTiff --NoDataValue=0 '
         '--creation-option TILED=YES --creation-option COMPRESS=LZW --creation-option NUM_THREADS=ALL_CPUS'
     )
-    subprocess.check_call(cmd.split(' '))
+    subprocess.run(cmd.split(' '), check=True)
 
     # Performs the inverse of the operation performed by MintPy:
     # https://github.com/insarlab/MintPy/blob/df96e0b73f13cc7e2b6bfa57d380963f140e3159/src/mintpy/objects/stackDict.py#L739-L745
@@ -372,7 +372,7 @@ def translate_outputs(isce_output_dir: Path, product_name: str, pixel_size: floa
         '--calc (90+A)*pi/180 --type Float32 --format GTiff --NoDataValue=0 '
         '--creation-option TILED=YES --creation-option COMPRESS=LZW --creation-option NUM_THREADS=ALL_CPUS'
     )
-    subprocess.check_call(cmd.split(' '))
+    subprocess.run(cmd.split(' '), check=True)
 
     ds = gdal.Open(str(isce_output_dir / 'filt_topophase.unw.geo'))
     geotransform = ds.GetGeoTransform()
@@ -470,7 +470,7 @@ def main():
                 '--NoDataValue 0 '
                 '--creation-option TILED=YES --creation-option COMPRESS=LZW --creation-option NUM_THREADS=ALL_CPUS'
             )
-            subprocess.check_call(cmd.split(' '))
+            subprocess.run(cmd.split(' '), check=True)
 
     make_browse_image(unwrapped_phase, f'{product_name}/{product_name}_unw_phase.png')
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -3,7 +3,6 @@
 import argparse
 import logging
 import os
-import site
 import subprocess
 import sys
 from collections import namedtuple
@@ -48,12 +47,6 @@ from hyp3_isce2.water_mask import create_water_mask
 gdal.UseExceptions()
 
 log = logging.getLogger(__name__)
-
-# ISCE needs its applications to be on the system path.
-# See https://github.com/isce-framework/isce2#setup-your-environment
-ISCE_APPLICATIONS = Path(site.getsitepackages()[0]) / 'isce' / 'applications'
-if str(ISCE_APPLICATIONS) not in os.environ['PATH'].split(os.pathsep):
-    os.environ['PATH'] = str(ISCE_APPLICATIONS) + os.pathsep + os.environ['PATH']
 
 
 def insar_tops_burst(

--- a/src/hyp3_isce2/stripmapapp_alos.py
+++ b/src/hyp3_isce2/stripmapapp_alos.py
@@ -1,11 +1,8 @@
-import os
 from pathlib import Path
 from typing import Union
 
 from isce.applications.stripmapApp import Insar
 from jinja2 import Template
-
-os.environ['PATH'] += os.pathsep + str(Path(os.environ['ISCE_HOME']) / 'applications')
 
 TEMPLATE_DIR = Path(__file__).parent / 'templates'
 

--- a/src/hyp3_isce2/utils.py
+++ b/src/hyp3_isce2/utils.py
@@ -1,7 +1,6 @@
 import shutil
 import subprocess
 
-import isce  # noqa
 import isceobj
 import numpy as np
 from isceobj.Util.ImageUtil.ImageLib import loadImage


### PR DESCRIPTION
There are two small refactors in this PR: 
1. Moves all the special ISCE2 environment variable, python path, and system path handling to `hyp3_isce2.__init__.py`, which ensures it's always done when using any object in this package. This also means we don't need to add:
   ```python
   import isce  # noqa
   ```
   to any of the package modules. That is, you can just use ISCE now without worrying about it's shenanigans.

2. Switches all subprocess commands to use `subprocess.run`, which is recommended:
    > The recommended approach to invoking subprocesses is to use the [run()](https://docs.python.org/3/library/subprocess.html#subprocess.run) function for all use cases it can handle.
    
    https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module