### PR TITLE
Reconfigure to use Ruff for linting and formatting

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,8 +7,6 @@ jobs:
     # Docs: https://github.com/ASFHyP3/actions
     uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.8.3
 
-  call-flake8-workflow:
+  call-ruff-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.8.3
-    with:
-      local_package_names: hyp3_isce2
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.8.3]
 
 ### Added
-* Ruff configuration and github action for Ruff-based static analysis
+* Ruff configuration and GitHub Action for Ruff-based static analysis
 
 ### Changed
 * Reformatted entire repository with the commands `ruff check --select I --fix .` and `ruff format .`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3]
+
+### Added
+* Ruff configuration and github action for Ruff-based static analysis
+
+### Changed
+* Reformatted entire repository with the commands `ruff check --select I --fix .` and `ruff format .`
+
 ## [0.8.2]
 ### Changed
 * All the special ISCE2 environment variable, python path, and system path handling has been moved to `hyp3_isce2.__init__.py` to ensure it's always done before using any object in this package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,12 @@ where = ["src"]
 
 [tool.ruff]
 line-length = 120
+src = ["src", "tests"]
+
+[tool.ruff.format]
+indent-style = "space"
+quote-style = "single"
+
+[tool.ruff.lint.isort]
+case-sensitive = true
+lines-after-imports = 2

--- a/src/hyp3_isce2/__init__.py
+++ b/src/hyp3_isce2/__init__.py
@@ -6,6 +6,8 @@ from pathlib import Path
 # Ensures all ISCE2 paths and environment variables are set when using this module, see:
 # https://github.com/isce-framework/isce2/blob/main/__init__.py#L41-L50
 import isce  # noqa: F401
+
+
 # ISCE2 also needs its applications to be on the system path, even though they say it's only "for convenience", see:
 # https://github.com/isce-framework/isce2#setup-your-environment
 ISCE_APPLICATIONS = str(Path(os.environ['ISCE_HOME']) / 'applications')

--- a/src/hyp3_isce2/etc/download_example.py
+++ b/src/hyp3_isce2/etc/download_example.py
@@ -11,6 +11,7 @@ Example 2: Downloading a pair of ascending/descending bursts and spoofing a SAFE
 
 from hyp3_isce2.burst import BurstParams, download_bursts, download_metadata, get_asf_session
 
+
 ref_desc = BurstParams('S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85', 'IW2', 'VV', 3)
 sec_desc = BurstParams('S1A_IW_SLC__1SDV_20200616T022252_20200616T022319_033036_03D3A3_5D11', 'IW2', 'VV', 3)
 ref_asc = BurstParams('S1A_IW_SLC__1SDV_20200608T142544_20200608T142610_032927_03D069_14F4', 'IW1', 'VV', 1)

--- a/src/hyp3_isce2/insar_stripmap.py
+++ b/src/hyp3_isce2/insar_stripmap.py
@@ -20,6 +20,7 @@ from hyp3_isce2 import stripmapapp_alos as stripmapapp
 from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.logging import configure_root_logger
 
+
 log = logging.getLogger(__name__)
 
 

--- a/src/hyp3_isce2/insar_tops.py
+++ b/src/hyp3_isce2/insar_tops.py
@@ -9,8 +9,7 @@ from shutil import copyfile, make_archive
 from hyp3lib.aws import upload_file_to_s3
 from hyp3lib.get_orb import downloadSentinelOrbitFile
 
-from hyp3_isce2 import slc
-from hyp3_isce2 import topsapp
+from hyp3_isce2 import slc, topsapp
 from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.logging import configure_root_logger
 from hyp3_isce2.s1_auxcal import download_aux_cal

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -28,7 +28,7 @@ from hyp3_isce2.burst import (
     get_isce2_burst_bbox,
     get_product_name,
     get_region_of_interest,
-    validate_bursts
+    validate_bursts,
 )
 from hyp3_isce2.dem import download_dem_for_isce2
 from hyp3_isce2.logging import configure_root_logger

--- a/src/hyp3_isce2/stripmapapp_alos.py
+++ b/src/hyp3_isce2/stripmapapp_alos.py
@@ -4,6 +4,7 @@ from typing import Union
 from isce.applications.stripmapApp import Insar
 from jinja2 import Template
 
+
 TEMPLATE_DIR = Path(__file__).parent / 'templates'
 
 STRIPMAPAPP_STEPS = [

--- a/src/hyp3_isce2/topsapp.py
+++ b/src/hyp3_isce2/topsapp.py
@@ -5,6 +5,7 @@ from isce.applications.topsApp import TopsInSAR
 from jinja2 import Template
 from osgeo import gdal
 
+
 gdal.UseExceptions()
 
 TEMPLATE_DIR = Path(__file__).parent / 'templates'

--- a/src/hyp3_isce2/utils.py
+++ b/src/hyp3_isce2/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 from isceobj.Util.ImageUtil.ImageLib import loadImage
 from osgeo import gdal
 
+
 gdal.UseExceptions()
 
 

--- a/src/hyp3_isce2/water_mask.py
+++ b/src/hyp3_isce2/water_mask.py
@@ -14,6 +14,7 @@ from shapely import geometry, wkt
 
 from hyp3_isce2.utils import GDALConfigManager
 
+
 gdal.UseExceptions()
 
 

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -9,6 +9,7 @@ from rasterio import CRS
 
 from hyp3_isce2 import dem
 
+
 MOCK_DEM_ARRAY = np.ones((3600, 3600), dtype=float)
 MOCK_DEM_ARRAY[:, 1000] = np.nan
 MOCK_DEM_ARRAY[:, 2000] = 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,8 +9,9 @@ from hyp3_isce2.utils import (
     make_browse_image,
     oldest_granule_first,
     resample_to_radar,
-    utm_from_lon_lat
+    utm_from_lon_lat,
 )
+
 
 gdal.UseExceptions()
 

--- a/tests/test_water_mask.py
+++ b/tests/test_water_mask.py
@@ -3,6 +3,7 @@ from osgeo import gdal
 
 from hyp3_isce2 import water_mask
 
+
 gdal.UseExceptions()
 
 


### PR DESCRIPTION
This PR swaps calling the reusable flake8 workflow for the new reusable ruff workflow. Also adds new ruff configuration options to the pyproject.toml.

Still deciding whether or not to reformat the entire repository within this PR.