### PR TITLE
Multi-Burst Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,28 @@ The HyP3-ISCE2 plugin provides a set of workflows (accessible directly in Python
 - `insar_tops_burst`: A workflow for creating multi-bursts Sentinel-1 geocoded unwrapped interferogram using ISCE2's TOPS processing workflow 
 ---
 
-To run a workflow, simply run `python -m hyp3_isce2 ++process [WORKFLOW_NAME] [WORKFLOW_ARGS]`. For example, to run the `insar_tops_burst` workflow:
+To run a workflow, simply run `python -m hyp3_isce2 ++process [WORKFLOW_NAME] [WORKFLOW_ARGS]`. For example, to run the `insar_tops_burst` workflow with a single burst pair:
 
 ```
 python -m hyp3_isce2 ++process insar_tops_burst \
-  --reference S1_136231_IW2_20200604T022312_VV_7C85-BURST S1_136231_IW3_20200604T022313_VV_7C85-BURST\
-  --secondary S1_136231_IW2_20200616T022313_VV_5D11-BURST S1_136231_IW3_20200616T022314_VV_5D11-BURST\
+  S1_136231_IW2_20200604T022312_VV_7C85-BURST\
+  S1_136231_IW2_20200616T022313_VV_5D11-BURST\
   --looks 20x4 \
   --apply-water-mask True
 ```
 
-This command will create a Sentinel-1 interferogram that contains a deformation signal related to a 
-2020 Iranian earthquake. 
+and, for multiple burst pairs:
+
+```
+python -m hyp3_isce2 ++process insar_tops_burst \
+  "S1_136231_IW2_20200604T022312_VV_7C85-BURST S1_136232_IW2_20200604T022315_VV_7C85-BURST"\
+  "S1_136231_IW2_20200616T022313_VV_5D11-BURST S1_136232_IW2_20200616T022316_VV_5D11-BURST"\
+  --looks 20x4 \
+  --apply-water-mask True
+```
+
+These commands will both create a Sentinel-1 interferogram that contains a deformation signal related to a 
+2020 Iranian earthquake.
 
 ### Product Merging Utility Usage
 **This feature is under active development and is subject to change!**

--- a/src/hyp3_isce2/insar_tops.py
+++ b/src/hyp3_isce2/insar_tops.py
@@ -109,7 +109,6 @@ def insar_tops_packaged(
     azimuth_looks: int = 4,
     range_looks: int = 20,
     apply_water_mask: bool = True,
-    download: bool = True,
     bucket: str = None,
     bucket_prefix: str = '',
 ) -> Path:
@@ -137,8 +136,8 @@ def insar_tops_packaged(
     do_download = os.path.exists(f'{reference}.SAFE') and os.path.exists(f'{secondary}.SAFE')
 
     insar_tops(
-        reference=reference,
-        secondary=secondary,
+        reference_scene=reference,
+        secondary_scene=secondary,
         swaths=swaths,
         polarization=polarization,
         azimuth_looks=azimuth_looks,

--- a/src/hyp3_isce2/insar_tops.py
+++ b/src/hyp3_isce2/insar_tops.py
@@ -133,10 +133,20 @@ def insar_tops_packaged(
     pixel_size = packaging.get_pixel_size(f'{range_looks}x{azimuth_looks}')
 
     log.info('Begin ISCE2 TopsApp run')
-    if os.path.exists(f'{reference}.SAFE') and os.path.exists(f'{secondary}.SAFE'):
-        insar_tops(reference, secondary, apply_water_mask=apply_water_mask, download=False)
-    else:
-        insar_tops(reference, secondary, apply_water_mask=apply_water_mask)
+
+    do_download = os.path.exists(f'{reference}.SAFE') and os.path.exists(f'{secondary}.SAFE')
+
+    insar_tops(
+        reference=reference,
+        secondary=secondary,
+        swaths=swaths,
+        polarization=polarization,
+        azimuth_looks=azimuth_looks,
+        range_looks=range_looks,
+        apply_water_mask=apply_water_mask,
+        download=do_download
+    )
+
     log.info('ISCE2 TopsApp run completed successfully')
 
     product_name = packaging.get_product_name(reference, secondary, pixel_spacing=int(pixel_size))

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -274,7 +274,7 @@ def main():
         'granules',
         type=str.split,
         nargs='+',
-        help='List of references in quotes and list of secondaries in quotes i.e. "ref" "sec" or "ref1 ref2" "sec1 sec2"'
+        help='List of references and list of secondaries i.e. ref sec or "ref1 ref2" "sec1 sec2"'
     )
 
     args = parser.parse_args()

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -270,26 +270,31 @@ def main():
         default=False,
         help='Apply a water body mask before unwrapping.',
     )
-    # Allows granules to be given as a space-delimited list of strings (e.g. foo bar) or as a single
-    # quoted string that contains spaces (e.g. "foo bar"). AWS Batch uses the latter format when
-    # invoking the container command.
-    parser.add_argument('--reference', type=str.split, nargs='+', help='List of granules for the reference bursts')
-    parser.add_argument('--secondary', type=str.split, nargs='+', help='List of granules for the secondary bursts')
+    parser.add_argument(
+        'granules',
+        type=str.split,
+        nargs='+',
+        help='List of references in quotes and list of secondaries in quotes i.e. "ref" "sec" or "ref1 ref2" "sec1 sec2"'
+    )
 
     args = parser.parse_args()
 
-    args.reference = [item for sublist in args.reference for item in sublist]
-    args.secondary = [item for sublist in args.secondary for item in sublist]
-    if len(args.reference) != len(args.secondary):
-        parser.error('Number of reference and secondary granules must be the same')
+    granules = args.granules
+    if len(granules) != 2:
+        parser.error('No more than two lists of granules may be provided.')
+    if len(granules[0]) != len(granules[1]):
+        parser.error('Number of references must match the number of secondaries.')
+
+    references = granules[0]
+    secondaries = granules[1]
 
     configure_root_logger()
     log.debug(' '.join(sys.argv))
 
-    if len(args.reference) == 1:
+    if len(references) == 1:
         insar_tops_single_burst(
-            reference=args.reference[0],
-            secondary=args.secondary[0],
+            reference=references[0],
+            secondary=secondaries[0],
             looks=args.looks,
             apply_water_mask=args.apply_water_mask,
             bucket=args.bucket,
@@ -297,8 +302,8 @@ def main():
         )
     else:
         insar_tops_multi_burst(
-            reference=args.reference,
-            secondary=args.secondary,
+            reference=references,
+            secondary=secondaries,
             looks=args.looks,
             apply_water_mask=args.apply_water_mask,
             bucket=args.bucket,


### PR DESCRIPTION
Changes burst workflow back to using `granules` for reference and secondary inputs. This supports the multi-burst workflow and the single-burst workflow.