### PR TITLE
jth mypy changes

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,12 +5,13 @@ on: push
 jobs:
   call-secrets-analysis-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.13.2
 
   call-ruff-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.14.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.13.2
 
   call-mypy-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@0.14.0
+    # TODO: update version tag after actions release
+    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@develop

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -92,9 +92,9 @@ class BurstMetadata:
                 setattr(self, files[name], content)
                 setattr(self, f'{files[name]}_name', elem.attrib['source_filename'])
             else:
-                raise AttributeError(f'Could not find "content" attribute in {name}.')
+                raise ValueError(f'Could not find "content" attribute in {name}.')
 
-        file_paths = [str(elements.attrib['href']) for elements in self.manifest.findall('.//fileLocation')]
+        file_paths = [elements.attrib['href'] for elements in self.manifest.findall('.//fileLocation')]
         pattern = f'^./measurement/s1.*{self.swath.lower()}.*{self.polarization.lower()}.*.tiff$'
         self.measurement_name = [Path(path).name for path in file_paths if re.search(pattern, path)][0]
 
@@ -102,7 +102,7 @@ class BurstMetadata:
         if orbit_direction:
             self.orbit_direction = orbit_direction.lower()
         else:
-            raise AttributeError(f'Could not find "pass" attribute in {name}.')
+            raise ValueError(f'Could not find "pass" attribute in {name}.')
 
 
 def create_burst_request_url(params: BurstParams, content_type: str) -> str:

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -73,8 +73,8 @@ class BurstMetadata:
         metadata = metadata[1]
 
         names = [file.attrib['source_filename'] for file in metadata]
-        lengths = [len(str(name).split('-')) for name in names]
-        swaths = [str(name).split('-')[length - 8] for name, length in zip(names, lengths)]
+        lengths = [len(name.split('-')) for name in names]
+        swaths = [name.split('-')[length - 8] for name, length in zip(names, lengths)]
         products = [x.tag for x in metadata]
         swaths_and_products = list(zip(swaths, products))
 


### PR DESCRIPTION
Changes:
- Downgrade some of our reusable actions from `v0.14.0` (not yet released)
- Remove some unnecessary `str()` casts (I confirmed with [`reveal_type`](https://mypy.readthedocs.io/en/latest/common_issues.html#reveal-type) that mypy already correctly infers those types as `str`)
- Change some usages of [`AttributeError`](https://docs.python.org/3.11/library/exceptions.html#AttributeError) to [`ValueError`](https://docs.python.org/3.11/library/exceptions.html#ValueError), because `AttributeError` specifically refers to Python object attributes, which isn't how we're using exceptions in this case.