### PR TITLE
Burst validation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4]
+
+### Changed
+- Improved error messages for validating the reference and secondary scenes passed to the `insar_tops_burst` workflow.
+
+### Fixed
+- Refined temporal requirements for scenes passed to the `insar_tops_burst` workflow, to allow the acquisition to cross midnight. Previously, the reference scenes were required to fall on one calendar day and the secondary scenes on a different calendar day. Now, each list of scenes must fall within a two-minute temporal window (with reference older than secondary, as before).
+- Removed the unused `swaths` parameter from the `hyp3_isce2.insar_tops_burst.insar_tops_multi_burst` function.
+
 ## [2.1.3]
 ### Changed
 - Updated download URLs for Sentinel-1 AUX_CAL files.

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -444,10 +444,14 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
     sec_datetimes = sorted(_burst_datetime(g) for g in secondary)
 
     if ref_datetimes[-1] - ref_datetimes[0] > timedelta(minutes=2):
-        raise ValueError('Reference scenes must fall within a 2-minute window in order to ensure they were collected during the same pass')
+        raise ValueError(
+            'Reference scenes must fall within a 2-minute window in order to ensure they were collected during the same pass'
+        )
 
     if sec_datetimes[-1] - sec_datetimes[0] > timedelta(minutes=2):
-        raise ValueError('Secondary scenes must fall within a 2-minute window in order to ensure they were collected during the same pass')
+        raise ValueError(
+            'Secondary scenes must fall within a 2-minute window in order to ensure they were collected during the same pass'
+        )
 
     if ref_datetimes[-1] >= sec_datetimes[0]:
         raise ValueError('Reference scenes must be older than secondary scenes')

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -421,10 +421,6 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
             f'Must provide the same number of reference and secondary scenes, got {len(reference)} reference and {len(secondary)} secondary'
         )
 
-    ref_num_swath_pol = [_num_swath_pol(g) for g in reference]
-    sec_num_swath_pol = [_num_swath_pol(g) for g in secondary]
-
-   
     for ref, sec in zip(reference, secondary):
         if _num_swath_pol(ref) != _num_swath_pol(sec):
             raise ValueError(

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -392,6 +392,14 @@ def get_burst_params(scene_name: str) -> BurstParams:
     )
 
 
+def _num_swath_pol(scene: str) -> str:
+    parts = scene.split('_')
+    num = parts[1]
+    swath = parts[2]
+    pol = parts[4]
+    return '_'.join([num, swath, pol])
+
+
 def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> None:
     """Check whether the reference and secondary bursts are valid.
 
@@ -441,14 +449,6 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
 
     if ref_dates[0] >= sec_dates[0]:
         raise ValueError('Reference scenes must be older than secondary scenes')
-
-
-def _num_swath_pol(scene: str) -> str:
-    parts = scene.split('_')
-    num = parts[1]
-    swath = parts[2]
-    pol = parts[4]
-    return '_'.join([num, swath, pol])
 
 
 def load_burst_position(swath_xml_path: str, burst_number: int) -> BurstPosition:

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -422,22 +422,22 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
                 f'Number + swath + polarization identifier does not match for reference scene {reference[i]} and secondary scene {secondary[i]}'
             )
 
-    pols = sorted(set(g.split('_')[4] for g in reference))
+    pols = list(set(g.split('_')[4] for g in reference))
 
     if len(pols) > 1:
-        raise ValueError(f'Scenes must have the same polarization. Polarizations present: {", ".join(pols)}')
+        raise ValueError(f'Scenes must have the same polarization. Polarizations present: {", ".join(sorted(pols))}')
 
     if pols[0] not in ['VV', 'HH']:
         raise ValueError(f'{pols[0]} polarization is not currently supported, only VV and HH')
 
-    ref_dates = sorted(set(g.split('_')[3][:8] for g in reference))
-    sec_dates = sorted(set(g.split('_')[3][:8] for g in secondary))
+    ref_dates = list(set(g.split('_')[3][:8] for g in reference))
+    sec_dates = list(set(g.split('_')[3][:8] for g in secondary))
 
     if len(ref_dates) > 1:
-        raise ValueError(f'Reference scenes must be from a single date. Dates present: {", ".join(ref_dates)}')
+        raise ValueError(f'Reference scenes must be from a single date. Dates present: {", ".join(sorted(ref_dates))}')
 
     if len(sec_dates) > 1:
-        raise ValueError(f'Secondary scenes must be from a single date. Dates present: {", ".join(sec_dates)}')
+        raise ValueError(f'Secondary scenes must be from a single date. Dates present: {", ".join(sorted(sec_dates))}')
 
     if ref_dates[0] >= sec_dates[0]:
         raise ValueError('Reference scenes must be older than secondary scenes')

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -424,10 +424,11 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
     ref_num_swath_pol = [_num_swath_pol(g) for g in reference]
     sec_num_swath_pol = [_num_swath_pol(g) for g in secondary]
 
-    for i in range(len(reference)):
-        if ref_num_swath_pol[i] != sec_num_swath_pol[i]:
+   
+    for ref, sec in zip(reference, secondary):
+        if _num_swath_pol(ref) != _num_swath_pol(sec):
             raise ValueError(
-                f'Number + swath + polarization identifier does not match for reference scene {reference[i]} and secondary scene {secondary[i]}'
+                f'Number + swath + polarization identifier does not match for reference scene {ref} and secondary scene {sec}'
             )
 
     pols = list(set(g.split('_')[4] for g in reference))

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -407,6 +407,7 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
     if len(reference) < 1 or len(secondary) < 1:
         raise ValueError('Must include at least 1 reference and 1 secondary burst')
     if len(reference) != len(secondary):
+        # TODO: report number of each
         raise ValueError('Must have the same number of reference and secondary bursts')
 
     ref_num_swath_pol = sorted(g.split('_')[1] + '_' + g.split('_')[2] + '_' + g.split('_')[4] for g in reference)

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -444,10 +444,10 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
     sec_datetimes = sorted(_burst_datetime(g) for g in secondary)
 
     if ref_datetimes[-1] - ref_datetimes[0] > timedelta(minutes=2):
-        raise ValueError('Reference scenes must fall within a 2-minute window')
+        raise ValueError('Reference scenes must fall within a 2-minute window in order to ensure they were collected during the same pass')
 
     if sec_datetimes[-1] - sec_datetimes[0] > timedelta(minutes=2):
-        raise ValueError('Secondary scenes must fall within a 2-minute window')
+        raise ValueError('Secondary scenes must fall within a 2-minute window in order to ensure they were collected during the same pass')
 
     if ref_datetimes[-1] >= sec_datetimes[0]:
         raise ValueError('Reference scenes must be older than secondary scenes')

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -418,7 +418,9 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
 
     for i in range(len(reference)):
         if ref_num_swath_pol[i] != sec_num_swath_pol[i]:
-            raise ValueError(f'Number + swath + polarization identifier does not match for reference scene {reference[i]} and secondary scene {secondary[i]}')
+            raise ValueError(
+                f'Number + swath + polarization identifier does not match for reference scene {reference[i]} and secondary scene {secondary[i]}'
+            )
 
     pols = sorted(set(g.split('_')[4] for g in reference))
 

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -418,10 +418,10 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
         msg += f'    Secondary IDs: {sec_num_swath_pol}'
         raise ValueError(msg)
 
-    pols = list(set(g.split('_')[4] for g in reference + secondary))
+    pols = sorted(set(g.split('_')[4] for g in reference + secondary))
 
     if len(pols) > 1:
-        raise ValueError(f'All bursts must have a single polarization. Polarizations present: {" ".join(pols)}')
+        raise ValueError(f'All bursts must have a single polarization. Polarizations present: {", ".join(pols)}')
 
     if pols[0] not in ['VV', 'HH']:
         raise ValueError(f'{pols[0]} polarization is not currently supported, only VV and HH.')

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -438,7 +438,7 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
         raise ValueError(f'Secondary scenes must be from a single date. Dates present: {", ".join(sec_dates)}')
 
     if ref_dates[0] >= sec_dates[0]:
-        raise ValueError('Reference granules must be older than secondary granules')
+        raise ValueError('Reference scenes must be older than secondary scenes')
 
 
 def _num_swath_pol(scene: str) -> str:

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -438,15 +438,6 @@ def validate_bursts(reference: str | list[str], secondary: str | list[str]) -> N
     ref_dates = list(set(g.split('_')[3][:8] for g in reference))
     sec_dates = list(set(g.split('_')[3][:8] for g in secondary))
 
-    if len(ref_dates) > 1:
-        raise ValueError(f'Reference scenes must be from a single date. Dates present: {", ".join(sorted(ref_dates))}')
-
-    if len(sec_dates) > 1:
-        raise ValueError(f'Secondary scenes must be from a single date. Dates present: {", ".join(sorted(sec_dates))}')
-
-    if ref_dates[0] >= sec_dates[0]:
-        raise ValueError('Reference scenes must be older than secondary scenes')
-
 
 def load_burst_position(swath_xml_path: str, burst_number: int) -> BurstPosition:
     """Get the tiff resolution and position parameters for a burst.

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -532,7 +532,7 @@ def evenly_subset_position(position: BurstPosition, rg_looks, az_looks) -> Burst
         position.n_lines, position.first_valid_line, position.n_valid_lines, az_looks
     )
     n_lines_remove = position.n_lines - even_n_lines
-    even_sensing_stop = position.sensing_stop - timedelta(seconds=position.azimuth_time_interval * (n_lines_remove))
+    even_sensing_stop = position.sensing_stop - timedelta(seconds=position.azimuth_time_interval * n_lines_remove)
 
     clip_position = BurstPosition(
         n_lines=even_n_lines,
@@ -556,7 +556,7 @@ def multilook_position(position: BurstPosition, rg_looks: int, az_looks: int) ->
         rg_looks: The number of range looks.
         az_looks: The number of azimuth looks.
     """
-    multilook_position = BurstPosition(
+    return BurstPosition(
         n_lines=int(position.n_lines / az_looks),
         n_samples=int(position.n_samples / rg_looks),
         first_valid_line=int(position.first_valid_line / az_looks),
@@ -567,7 +567,6 @@ def multilook_position(position: BurstPosition, rg_looks: int, az_looks: int) ->
         range_pixel_size=position.range_pixel_size * rg_looks,
         sensing_stop=position.sensing_stop,
     )
-    return multilook_position
 
 
 def safely_multilook(

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -219,7 +219,6 @@ def insar_tops_single_burst(
 def insar_tops_multi_burst(
     reference: list[str],
     secondary: list[str],
-    swaths: list = [1, 2, 3],  # TODO: mutable, and unused; ruff option for these?
     looks: str = '20x4',
     apply_water_mask=False,
     bucket: str | None = None,

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -219,7 +219,7 @@ def insar_tops_single_burst(
 def insar_tops_multi_burst(
     reference: list[str],
     secondary: list[str],
-    swaths: list = [1, 2, 3],
+    swaths: list = [1, 2, 3],  # TODO: mutable, and unused; ruff option for these?
     looks: str = '20x4',
     apply_water_mask=False,
     bucket: str | None = None,

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -298,7 +298,7 @@ def test_validate_bursts():
             ],
         )
 
-    with pytest.raises(ValueError, match=r'^Reference granules must be older than secondary granules$'):
+    with pytest.raises(ValueError, match=r'^Reference scenes must be older than secondary scenes$'):
         burst.validate_bursts(
             ['S1_000000_IW1_20200201T000000_VV_0000-BURST'],
             ['S1_000000_IW1_20200101T000000_VV_0000-BURST'],

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -208,10 +208,10 @@ def test_validate_bursts():
         ],
     )
 
-    with pytest.raises(ValueError, match=r'Must include at least 1.*'):
+    with pytest.raises(ValueError, match='Must include at least 1 reference and 1 secondary burst'):
         burst.validate_bursts(['a'], [])
 
-    with pytest.raises(ValueError, match=r'Must have the same number.*'):
+    with pytest.raises(ValueError, match='Must have the same number of reference and secondary bursts'):
         burst.validate_bursts(['a', 'b'], ['c'])
 
     with pytest.raises(ValueError, match=r'.*burst ID sets do not match.*'):
@@ -220,7 +220,7 @@ def test_validate_bursts():
             ['S1_000000_IW2_20200201T000000_VV_0000-BURST'],
         )
 
-    with pytest.raises(ValueError, match=r'.*must have a single polarization.*'):
+    with pytest.raises(ValueError, match='All bursts must have a single polarization. Polarizations present: VH, VV'):
         burst.validate_bursts(
             [
                 'S1_000000_IW1_20200101T000000_VV_0000-BURST',
@@ -232,7 +232,7 @@ def test_validate_bursts():
             ],
         )
 
-    with pytest.raises(ValueError, match=r'.*polarization is not currently supported.*'):
+    with pytest.raises(ValueError, match='VH polarization is not currently supported, only VV and HH.'):
         burst.validate_bursts(
             [
                 'S1_000000_IW1_20200101T000000_VH_0000-BURST',
@@ -244,7 +244,7 @@ def test_validate_bursts():
             ],
         )
 
-    with pytest.raises(ValueError, match=r'.*must be from one date.*'):
+    with pytest.raises(ValueError, match='Reference granules must be from one date and secondary granules must be another.'):
         burst.validate_bursts(
             [
                 'S1_000000_IW1_20200101T000000_VV_0000-BURST',
@@ -256,7 +256,7 @@ def test_validate_bursts():
             ],
         )
 
-    with pytest.raises(ValueError, match=r'Reference granules must be older.*'):
+    with pytest.raises(ValueError, match='Reference granules must be older than secondary granules.'):
         burst.validate_bursts(
             'S1_000000_IW1_20200201T000000_VV_0000-BURST',
             'S1_000000_IW1_20200101T000000_VV_0000-BURST',

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -300,14 +300,14 @@ def test_validate_bursts():
 
     with pytest.raises(ValueError, match=r'^Reference scenes must be older than secondary scenes$'):
         burst.validate_bursts(
-            ['S1_000000_IW1_20200201T000000_VV_0000-BURST'],
-            ['S1_000000_IW1_20200201T000000_VV_0000-BURST'],
+            ['S1_000000_IW1_20200203T000000_VV_0000-BURST'],
+            ['S1_000000_IW1_20200203T000000_VV_0000-BURST'],
         )
 
     with pytest.raises(ValueError, match=r'^Reference scenes must be older than secondary scenes$'):
         burst.validate_bursts(
-            ['S1_000000_IW1_20200201T000000_VV_0000-BURST'],
-            ['S1_000000_IW1_20200101T000000_VV_0000-BURST'],
+            ['S1_000000_IW1_20200203T000000_VV_0000-BURST'],
+            ['S1_000000_IW1_20200202T000000_VV_0000-BURST'],
         )
 
 

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -301,6 +301,12 @@ def test_validate_bursts():
     with pytest.raises(ValueError, match=r'^Reference scenes must be older than secondary scenes$'):
         burst.validate_bursts(
             ['S1_000000_IW1_20200201T000000_VV_0000-BURST'],
+            ['S1_000000_IW1_20200201T000000_VV_0000-BURST'],
+        )
+
+    with pytest.raises(ValueError, match=r'^Reference scenes must be older than secondary scenes$'):
+        burst.validate_bursts(
+            ['S1_000000_IW1_20200201T000000_VV_0000-BURST'],
             ['S1_000000_IW1_20200101T000000_VV_0000-BURST'],
         )
 

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -218,11 +218,15 @@ def test_validate_bursts():
         burst.validate_bursts([], [])
 
     with pytest.raises(
-        ValueError, match=r'^Must provide the same number of reference and secondary scenes, got 2 reference and 1 secondary$'
+        ValueError,
+        match=r'^Must provide the same number of reference and secondary scenes, got 2 reference and 1 secondary$',
     ):
         burst.validate_bursts(['a', 'b'], ['c'])
 
-    with pytest.raises(ValueError, match=r'^Number \+ swath \+ polarization identifier does not match for reference scene S1_000001_IW1_20200101T000001_VV_0000\-BURST and secondary scene S1_000002_IW1_20200201T000001_VV_0000\-BURST$'):
+    with pytest.raises(
+        ValueError,
+        match=r'^Number \+ swath \+ polarization identifier does not match for reference scene S1_000001_IW1_20200101T000001_VV_0000\-BURST and secondary scene S1_000002_IW1_20200201T000001_VV_0000\-BURST$',
+    ):
         burst.validate_bursts(
             [
                 'S1_000000_IW1_20200101T000000_VV_0000-BURST',
@@ -285,7 +289,7 @@ def test_validate_bursts():
         )
 
     with pytest.raises(
-            ValueError, match=r'^Secondary scenes must be from a single date. Dates present: 20200201, 20200301$'
+        ValueError, match=r'^Secondary scenes must be from a single date. Dates present: 20200201, 20200301$'
     ):
         burst.validate_bursts(
             [

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -197,6 +197,12 @@ def test_num_swath_pol():
     assert burst._num_swath_pol('S1_068687_IW3_20230423T223824_HH_BA77-BURST') == '068687_IW3_HH'
 
 
+def test_burst_datetime():
+    assert burst._burst_datetime('S1_136231_IW2_20200604T022312_VV_7C85-BURST') == datetime(2020, 6, 4, 2, 23, 12)
+    assert burst._burst_datetime('S1_068687_IW3_20230423T223824_HH_BA77-BURST') == datetime(2023, 4, 23, 22, 38, 24)
+    assert burst._burst_datetime('S1_068687_IW3_20230403T020804_HH_BA77-BURST') == datetime(2023, 4, 3, 2, 8, 4)
+
+
 def test_validate_bursts():
     burst.validate_bursts(
         'S1_000000_IW1_20200101T000000_VV_0000-BURST',
@@ -276,6 +282,75 @@ def test_validate_bursts():
             [
                 'S1_000000_IW1_20200201T000000_VH_0000-BURST',
                 'S1_000000_IW1_20200201T000000_VH_0000-BURST',
+            ],
+        )
+
+    burst.validate_bursts(
+        [
+            'S1_000000_IW1_20250101T000000_VV_0000-BURST',
+            'S1_000001_IW1_20250101T000100_VV_0000-BURST',
+            'S1_000002_IW1_20250101T000200_VV_0000-BURST',
+        ],
+        [
+            'S1_000000_IW1_20250101T000201_VV_0000-BURST',
+            'S1_000001_IW1_20250101T000300_VV_0000-BURST',
+            'S1_000002_IW1_20250101T000401_VV_0000-BURST',
+        ],
+    )
+
+    with pytest.raises(ValueError, match=r'^Reference scenes must fall within a 2-minute window$'):
+        burst.validate_bursts(
+            [
+                'S1_000000_IW1_20250101T000000_VV_0000-BURST',
+                'S1_000001_IW1_20250101T000100_VV_0000-BURST',
+                'S1_000002_IW1_20250101T000201_VV_0000-BURST',
+            ],
+            [
+                'S1_000000_IW1_20250101T000201_VV_0000-BURST',
+                'S1_000001_IW1_20250101T000300_VV_0000-BURST',
+                'S1_000002_IW1_20250101T000401_VV_0000-BURST',
+            ],
+        )
+
+    with pytest.raises(ValueError, match=r'^Secondary scenes must fall within a 2-minute window$'):
+        burst.validate_bursts(
+            [
+                'S1_000000_IW1_20250101T000000_VV_0000-BURST',
+                'S1_000001_IW1_20250101T000100_VV_0000-BURST',
+                'S1_000002_IW1_20250101T000200_VV_0000-BURST',
+            ],
+            [
+                'S1_000000_IW1_20250101T000201_VV_0000-BURST',
+                'S1_000001_IW1_20250101T000300_VV_0000-BURST',
+                'S1_000002_IW1_20250101T000402_VV_0000-BURST',
+            ],
+        )
+
+    with pytest.raises(ValueError, match=r'^Reference scenes must be older than secondary scenes$'):
+        burst.validate_bursts(
+            [
+                'S1_000000_IW1_20250101T000000_VV_0000-BURST',
+                'S1_000001_IW1_20250101T000100_VV_0000-BURST',
+                'S1_000002_IW1_20250101T000200_VV_0000-BURST',
+            ],
+            [
+                'S1_000000_IW1_20250101T000200_VV_0000-BURST',
+                'S1_000001_IW1_20250101T000300_VV_0000-BURST',
+                'S1_000002_IW1_20250101T000400_VV_0000-BURST',
+            ],
+        )
+
+    with pytest.raises(ValueError, match=r'^Reference scenes must be older than secondary scenes$'):
+        burst.validate_bursts(
+            [
+                'S1_000000_IW1_20250101T000201_VV_0000-BURST',
+                'S1_000001_IW1_20250101T000300_VV_0000-BURST',
+                'S1_000002_IW1_20250101T000401_VV_0000-BURST',
+            ],
+            [
+                'S1_000000_IW1_20250101T000000_VV_0000-BURST',
+                'S1_000001_IW1_20250101T000100_VV_0000-BURST',
+                'S1_000002_IW1_20250101T000200_VV_0000-BURST',
             ],
         )
 

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -279,46 +279,6 @@ def test_validate_bursts():
             ],
         )
 
-    with pytest.raises(
-        ValueError, match=r'^Reference scenes must be from a single date. Dates present: 20200101, 20200102$'
-    ):
-        burst.validate_bursts(
-            [
-                'S1_000000_IW1_20200101T000000_VV_0000-BURST',
-                'S1_000001_IW1_20200102T000000_VV_0000-BURST',
-            ],
-            [
-                'S1_000000_IW1_20200201T000000_VV_0000-BURST',
-                'S1_000001_IW1_20200201T000000_VV_0000-BURST',
-            ],
-        )
-
-    with pytest.raises(
-        ValueError, match=r'^Secondary scenes must be from a single date. Dates present: 20200201, 20200301$'
-    ):
-        burst.validate_bursts(
-            [
-                'S1_000000_IW1_20200101T000000_VV_0000-BURST',
-                'S1_000001_IW1_20200101T000000_VV_0000-BURST',
-            ],
-            [
-                'S1_000000_IW1_20200301T000000_VV_0000-BURST',
-                'S1_000001_IW1_20200201T000000_VV_0000-BURST',
-            ],
-        )
-
-    with pytest.raises(ValueError, match=r'^Reference scenes must be older than secondary scenes$'):
-        burst.validate_bursts(
-            ['S1_000000_IW1_20200203T000000_VV_0000-BURST'],
-            ['S1_000000_IW1_20200203T000000_VV_0000-BURST'],
-        )
-
-    with pytest.raises(ValueError, match=r'^Reference scenes must be older than secondary scenes$'):
-        burst.validate_bursts(
-            ['S1_000000_IW1_20200203T000000_VV_0000-BURST'],
-            ['S1_000000_IW1_20200202T000000_VV_0000-BURST'],
-        )
-
 
 def test_load_burst_position(tmpdir):
     product = namedtuple('product', ['bursts'])

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -318,7 +318,7 @@ def test_validate_bursts_datetimes():
         ],
     )
 
-    with pytest.raises(ValueError, match=r'^Reference scenes must fall within a 2-minute window$'):
+    with pytest.raises(ValueError, match=r'^Reference scenes must fall within a 2-minute window .*'):
         burst.validate_bursts(
             [
                 'S1_000000_IW1_20250101T000000_VV_0000-BURST',
@@ -332,7 +332,7 @@ def test_validate_bursts_datetimes():
             ],
         )
 
-    with pytest.raises(ValueError, match=r'^Reference scenes must fall within a 2-minute window$'):
+    with pytest.raises(ValueError, match=r'^Reference scenes must fall within a 2-minute window .*'):
         burst.validate_bursts(
             [
                 # Test with reference datetimes unsorted
@@ -347,7 +347,7 @@ def test_validate_bursts_datetimes():
             ],
         )
 
-    with pytest.raises(ValueError, match=r'^Secondary scenes must fall within a 2-minute window$'):
+    with pytest.raises(ValueError, match=r'^Secondary scenes must fall within a 2-minute window .*'):
         burst.validate_bursts(
             [
                 'S1_000000_IW1_20250101T000000_VV_0000-BURST',
@@ -361,7 +361,7 @@ def test_validate_bursts_datetimes():
             ],
         )
 
-    with pytest.raises(ValueError, match=r'^Secondary scenes must fall within a 2-minute window$'):
+    with pytest.raises(ValueError, match=r'^Secondary scenes must fall within a 2-minute window .*'):
         burst.validate_bursts(
             [
                 'S1_000000_IW1_20250101T000000_VV_0000-BURST',

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -192,6 +192,11 @@ def test_get_burst_params_multiple_results():
         mock_search.assert_called_once_with(product_list=['there are multiple copies of this burst'])
 
 
+def test_num_swath_pol():
+    assert burst._num_swath_pol('S1_136231_IW2_20200604T022312_VV_7C85-BURST') == '136231_IW2_VV'
+    assert burst._num_swath_pol('S1_068687_IW3_20230423T223824_HH_BA77-BURST') == '068687_IW3_HH'
+
+
 def test_validate_bursts():
     burst.validate_bursts(
         'S1_000000_IW1_20200101T000000_VV_0000-BURST',
@@ -313,11 +318,6 @@ def test_validate_bursts():
             ['S1_000000_IW1_20200203T000000_VV_0000-BURST'],
             ['S1_000000_IW1_20200202T000000_VV_0000-BURST'],
         )
-
-
-def test_num_swath_pol():
-    assert burst._num_swath_pol('S1_136231_IW2_20200604T022312_VV_7C85-BURST') == '136231_IW2_VV'
-    assert burst._num_swath_pol('S1_068687_IW3_20230423T223824_HH_BA77-BURST') == '068687_IW3_HH'
 
 
 def test_load_burst_position(tmpdir):


### PR DESCRIPTION
Burst validation updates to go with https://github.com/ASFHyP3/hyp3/pull/2631

Changes include:
- Standardized around "scene" instead of "burst" to refer to scene names (I'm open to being persuaded otherwise)
- Improved some error messages to include more specific information about the problem
- Fixed some pycharm warnings (redundant parens, `multilook_position` variable shadows function name)
- Removed unused `swaths` param from `insar_tops_multi_burst`

TODO:

- [x] `TODO` items in code
- [x] Add/update tests
- [x] Midnight boundary edge case
- [x] Changelog