### PR TITLE
Release v2.1.6 - Buxfix too many VRTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6]
+
+### Fixed
+- Fixed a [region of interest bug](https://github.com/ASFHyP3/hyp3-isce2/issues/165) that caused `ValueError: There should only be 2 VRT files` when there should not have been multiple VRTs.
+
 ## [2.1.5]
 
 ### Fixed

--- a/requirements-static.txt
+++ b/requirements-static.txt
@@ -1,3 +1,3 @@
-ruff==0.9.9
+ruff==0.9.10
 mypy==1.15.0
 types-lxml

--- a/requirements-static.txt
+++ b/requirements-static.txt
@@ -1,3 +1,3 @@
-ruff==0.9.10
+ruff==0.11.0
 mypy==1.15.0
 types-lxml

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -303,7 +303,7 @@ def get_region_of_interest(
 ) -> tuple[float, float, float, float]:
     """Get the region of interest for two bursts that will lead to single burst ISCE2 processing.
 
-    For a descending orbit, the roi is in the lower left corner of the two bursts, and for an ascending orbit the roi is
+    For a descending orbit, the roi is in the upper left corner of the two bursts, and for an ascending orbit the roi is
     in the upper right corner.
 
     Args:
@@ -317,7 +317,7 @@ def get_region_of_interest(
     intersection = ref_bbox.intersection(sec_bbox)
     bounds = intersection.bounds
 
-    x, y = (0, 1) if is_ascending else (2, 1)
+    x, y = (2, 3) if is_ascending else (0, 3)
     roi = geometry.Point(bounds[x], bounds[y]).buffer(0.005)
     return roi.bounds
 

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -89,14 +89,24 @@ def test_get_region_of_interest(tmp_path, orbit):
     This diagram shows the burst layout for a descending orbit (the 0 indicates the region of interest):
           +---------------+
           |               |
-       +--+------------+  |
+       0--+------------+  |
        |  |            |  |
     +--+--+---------+--+--+
     |  |            |  |
-    |  +------------+--0
+    |  +------------+--+
     |               |
     +---------------+
-    The diagram for an ascending orbit is the same, but rotated 180 degrees.
+
+    And for an ascending orbit:
+    +--------------+
+    |              |
+    |  +------------+--0
+    |  |            |  |
+    +--+--+---------+--+--+
+       |  |            |  |
+       +--+------------+  |
+          |               |
+          +---------------+
     """
     options = {'descending': [REF_DESC, SEC_DESC], 'ascending': [REF_ASC, SEC_ASC]}
 


### PR DESCRIPTION
Golden tests pass:
https://github.com/ASFHyP3/hyp3-testing/actions/runs/13910811419/job/38924457041

The two pairs mentioned in #165 also process just fine now:
https://hyp3-test-api.asf.alaska.edu/jobs?name=hyp3-isce2-v2.1.6-vrts&user_id=jhkennedy

If needed, I could track down a larger variety of these failures.