### PR TITLE
Use `burst2safe` for Single Burst Jobs to Fix Multiple VRT Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.6
+
+### Changed
+- The `insar_tops_single_burst` workflow now uses [burst2safe](https://github.com/ASFHyP3/burst2safe) to eliminate the use of a region of interest with ISCE2, which was causing a [bug where multiple vrts would be cropped by ISCE2](https://github.com/ASFHyP3/hyp3-isce2/issues/165).
+
 ## [2.1.6]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## 2.2.6
 
 ### Changed
-- The `insar_tops_single_burst` workflow now uses [burst2safe](https://github.com/ASFHyP3/burst2safe) to eliminate the use of a region of interest with ISCE2, which was causing a [bug where multiple vrts would be cropped by ISCE2](https://github.com/ASFHyP3/hyp3-isce2/issues/165).
+- The `insar_tops_single_burst` workflow now uses [burst2safe](https://github.com/ASFHyP3/burst2safe) to eliminate the use of a region of interest with single-burst jobs, which was causing a [bug where multiple vrts would be cropped by ISCE2](https://github.com/ASFHyP3/hyp3-isce2/issues/165).
 
 ## [2.1.6]
 

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -270,7 +270,7 @@ def spoof_safe(burst: BurstMetadata, burst_tiff_path: Path, base_path: Path = Pa
     return safe_path
 
 
-def get_isce2_burst_bbox(params: BurstParams, base_dir: Path | None = None) -> geometry.Polygon:
+def get_isce2_burst_bbox(safe: str, swath: int, polarization: str, base_dir: Path | None = None) -> geometry.Polygon:
     """Get the bounding box of a Sentinel-1 burst using ISCE2.
     Using ISCE2 directly ensures that the bounding box is the same as the one used by ISCE2 for processing.
 
@@ -287,11 +287,11 @@ def get_isce2_burst_bbox(params: BurstParams, base_dir: Path | None = None) -> g
 
     s1_obj = Sentinel1()
     s1_obj.configure()
-    s1_obj.polarization = params.polarization.lower()
-    s1_obj.safe = [str(base_dir / f'{params.granule}.SAFE')]
-    s1_obj.swathNumber = int(params.swath[-1])
+    s1_obj.polarization = polarization.lower()
+    s1_obj.safe = [safe]
+    s1_obj.swathNumber = swath
     s1_obj.parse()
-    snwe = s1_obj.product.bursts[params.burst_number].getBbox()
+    snwe = s1_obj.product.getBbox()
 
     # convert from south, north, west, east -> minx, miny, maxx, maxy
     bbox = geometry.box(snwe[2], snwe[0], snwe[3], snwe[1])
@@ -317,7 +317,7 @@ def get_region_of_interest(
     intersection = ref_bbox.intersection(sec_bbox)
     bounds = intersection.bounds
 
-    x, y = (2, 3) if is_ascending else (0, 3)
+    x, y = (0, 1) if is_ascending else (0, 3)
     roi = geometry.Point(bounds[x], bounds[y]).buffer(0.005)
     return roi.bounds
 

--- a/src/hyp3_isce2/burst.py
+++ b/src/hyp3_isce2/burst.py
@@ -298,30 +298,6 @@ def get_isce2_burst_bbox(safe: str, swath: int, polarization: str, base_dir: Pat
     return bbox
 
 
-def get_region_of_interest(
-    ref_bbox: geometry.Polygon, sec_bbox: geometry.Polygon, is_ascending: bool = True
-) -> tuple[float, float, float, float]:
-    """Get the region of interest for two bursts that will lead to single burst ISCE2 processing.
-
-    For a descending orbit, the roi is in the upper left corner of the two bursts, and for an ascending orbit the roi is
-    in the upper right corner.
-
-    Args:
-        ref_bbox: The reference burst's bounding box.
-        sec_bbox: The secondary burst's bounding box.
-        is_ascending: Whether the orbit is ascending or descending.
-
-    Returns:
-        The region of interest as a tuple of (minx, miny, maxx, maxy).
-    """
-    intersection = ref_bbox.intersection(sec_bbox)
-    bounds = intersection.bounds
-
-    x, y = (0, 1) if is_ascending else (0, 3)
-    roi = geometry.Point(bounds[x], bounds[y]).buffer(0.005)
-    return roi.bounds
-
-
 def get_asf_session() -> requests.Session:
     """Get a requests session with an ASF URS cookie.
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -66,22 +66,21 @@ def insar_tops_burst(
     aux_cal_dir = Path('aux_cal')
     dem_dir = Path('dem')
 
-    ref_params = get_burst_params(reference_scene)
-    sec_params = get_burst_params(secondary_scene)
+    reference_safe_path = burst2safe([reference_scene], all_anns=True)
+    reference_safe = reference_safe_path.name.split('.')[0]
+    secondary_safe_path = burst2safe([secondary_scene], all_anns=True)
+    secondary_safe = secondary_safe_path.name.split('.')[0]
 
-    ref_metadata, _ = download_bursts([ref_params, sec_params])
+    polarization = reference_scene.split('_')[4]
 
-    is_ascending = ref_metadata.orbit_direction == 'ascending'
-    ref_footprint = get_isce2_burst_bbox(ref_params)
-    sec_footprint = get_isce2_burst_bbox(sec_params)
+    ref_footprint = get_isce2_burst_bbox(str(reference_safe_path), swath_number, polarization)
+    sec_footprint = get_isce2_burst_bbox(str(secondary_safe_path), swath_number, polarization)
 
-    insar_roi = get_region_of_interest(ref_footprint, sec_footprint, is_ascending=is_ascending)
     dem_roi = ref_footprint.intersection(sec_footprint).bounds
 
     if abs(dem_roi[0] - dem_roi[2]) > 180.0 and dem_roi[0] * dem_roi[2] < 0.0:
         raise ValueError('Products that cross the anti-meridian are not currently supported.')
 
-    log.info(f'InSAR ROI: {insar_roi}')
     log.info(f'DEM ROI: {dem_roi}')
 
     dem_path = download_dem_for_isce2(dem_roi, dem_name='glo_30', dem_dir=dem_dir, buffer=0, resample_20m=False)
@@ -95,18 +94,17 @@ def insar_tops_burst(
         geocode_dem_path = dem_path
 
     orbit_dir.mkdir(exist_ok=True, parents=True)
-    for granule in (ref_params.granule, sec_params.granule):
+    for granule in (reference_safe, secondary_safe):
         log.info(f'Downloading orbit file for {granule}')
         orbit_file = fetch_for_scene(granule, dir=orbit_dir)
         log.info(f'Got orbit file {orbit_file} from s1_orbits')
 
     config = topsapp.TopsappConfig(
-        reference_safe=f'{ref_params.granule}.SAFE',
-        secondary_safe=f'{sec_params.granule}.SAFE',
-        polarization=ref_params.polarization,
+        reference_safe=reference_safe_path,
+        secondary_safe=secondary_safe_path,
+        polarization=polarization,
         orbit_directory=str(orbit_dir),
         aux_cal_directory=str(aux_cal_dir),
-        roi=insar_roi,
         dem_filename=str(dem_path),
         geocode_dem_filename=str(geocode_dem_path),
         swaths=swath_number,
@@ -148,7 +146,7 @@ def insar_tops_burst(
     copyfile('merged/z.rdr.full.xml', 'merged/z.rdr.full.vrt.xml')
     topsapp.run_topsapp(start='geocode', end='geocode', config_xml=config_path)
 
-    return Path('merged')
+    return reference_safe_path, secondary_safe_path
 
 
 def insar_tops_single_burst(
@@ -164,7 +162,7 @@ def insar_tops_single_burst(
 
     log.info('Begin ISCE2 TopsApp run')
 
-    insar_tops_burst(
+    reference_safe_path, secondary_safe_path = insar_tops_burst(
         reference_scene=reference,
         secondary_scene=secondary,
         azimuth_looks=azimuth_looks,
@@ -208,6 +206,8 @@ def insar_tops_single_burst(
         range_looks=range_looks,
         multilook_position=multilook_position,
         apply_water_mask=apply_water_mask,
+        reference_safe=reference_safe_path,
+        secondary_safe=secondary_safe_path
     )
     output_zip = make_archive(base_name=product_name, format='zip', base_dir=product_name)
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -45,7 +45,7 @@ def insar_tops_burst(
     azimuth_looks: int = 4,
     range_looks: int = 20,
     apply_water_mask: bool = False,
-) -> Path:
+) -> tuple[Path, Path]:
     """Create a burst interferogram
 
     Args:
@@ -57,7 +57,7 @@ def insar_tops_burst(
         apply_water_mask: Whether to apply a pre-unwrap water mask
 
     Returns:
-        Path to results directory
+        Paths to reference and secondary safes
     """
     orbit_dir = Path('orbits')
     aux_cal_dir = Path('aux_cal')
@@ -203,8 +203,8 @@ def insar_tops_single_burst(
         range_looks=range_looks,
         multilook_position=multilook_position,
         apply_water_mask=apply_water_mask,
-        reference_safe=reference_safe_path,
-        secondary_safe=secondary_safe_path,
+        reference_safe=reference_safe_path.name,
+        secondary_safe=secondary_safe_path.name,
     )
     output_zip = make_archive(base_name=product_name, format='zip', base_dir=product_name)
 

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -16,10 +16,7 @@ from s1_orbits import fetch_for_scene
 
 from hyp3_isce2 import packaging, topsapp
 from hyp3_isce2.burst import (
-    download_bursts,
-    get_burst_params,
     get_isce2_burst_bbox,
-    get_region_of_interest,
     multilook_radar_merge_inputs,
     validate_bursts,
 )
@@ -207,7 +204,7 @@ def insar_tops_single_burst(
         multilook_position=multilook_position,
         apply_water_mask=apply_water_mask,
         reference_safe=reference_safe_path,
-        secondary_safe=secondary_safe_path
+        secondary_safe=secondary_safe_path,
     )
     output_zip = make_archive(base_name=product_name, format='zip', base_dir=product_name)
 

--- a/src/hyp3_isce2/merge_tops_bursts.py
+++ b/src/hyp3_isce2/merge_tops_bursts.py
@@ -1174,7 +1174,7 @@ def prepare_products(directory: Path) -> None:
         multilooked_swath_obj = modify_for_multilook(swath_products, swath_obj)
         multilooked_swath_obj.write_xml()
 
-        spoof_isce2_setup(swath_products, swath_obj)
+        spoof_isce2_setup(swath_products)
         swath_objs.append(copy.deepcopy(swath_obj))
         del swath_obj
 

--- a/src/hyp3_isce2/packaging.py
+++ b/src/hyp3_isce2/packaging.py
@@ -384,7 +384,8 @@ def make_parameter_file(
         multilook_position: Burst position for multilooked radar geometry products
         dem_name: Name of the DEM that is use
         dem_resolution: Resolution of the DEM
-
+        reference_safe: The name of the reference SAFE file (only necessary for single-burst)
+        secondary_safe: The name of the reference SAFE file (only necessary for single-burst)
     returns:
         None
     """

--- a/src/hyp3_isce2/packaging.py
+++ b/src/hyp3_isce2/packaging.py
@@ -384,8 +384,8 @@ def make_parameter_file(
         multilook_position: Burst position for multilooked radar geometry products
         dem_name: Name of the DEM that is use
         dem_resolution: Resolution of the DEM
-        reference_safe: The name of the reference SAFE file (only necessary for single-burst)
-        secondary_safe: The name of the reference SAFE file (only necessary for single-burst)
+        reference_safe: The name of the reference SAFE directory. Optional; will look for a `.SAFE` directory matching `reference_scene`  if not provided.
+        secondary_safe: The name of the reference SAFE directory. Optional; will look for a `.SAFE` directory matching `secondary_scene`  if not provided.
 
     returns:
         None

--- a/src/hyp3_isce2/packaging.py
+++ b/src/hyp3_isce2/packaging.py
@@ -400,7 +400,7 @@ def make_parameter_file(
     else:
         ref_tag = reference_scene[-4::]
         sec_tag = secondary_scene[-4::]
-    
+
     if reference_safe is None:
         reference_safe = [file for file in os.listdir('.') if file.endswith(f'{ref_tag}.SAFE')][0]
         secondary_safe = [file for file in os.listdir('.') if file.endswith(f'{sec_tag}.SAFE')][0]

--- a/src/hyp3_isce2/packaging.py
+++ b/src/hyp3_isce2/packaging.py
@@ -401,6 +401,7 @@ def make_parameter_file(
     else:
         ref_tag = reference_scene[-4::]
         sec_tag = secondary_scene[-4::]
+    if reference_safe is None:
         reference_safe = [file for file in os.listdir('.') if file.endswith(f'{ref_tag}.SAFE')][0]
         secondary_safe = [file for file in os.listdir('.') if file.endswith(f'{sec_tag}.SAFE')][0]
 

--- a/src/hyp3_isce2/packaging.py
+++ b/src/hyp3_isce2/packaging.py
@@ -384,8 +384,8 @@ def make_parameter_file(
         multilook_position: Burst position for multilooked radar geometry products
         dem_name: Name of the DEM that is use
         dem_resolution: Resolution of the DEM
-        reference_safe: The name of the reference SAFE directory. Optional; will look for a `.SAFE` directory matching `reference_scene`  if not provided.
-        secondary_safe: The name of the reference SAFE directory. Optional; will look for a `.SAFE` directory matching `secondary_scene`  if not provided.
+        reference_safe: The name of the reference SAFE directory. Optional; will look for a `.SAFE` directory matching `reference_scene` if not provided.
+        secondary_safe: The name of the reference SAFE directory. Optional; will look for a `.SAFE` directory matching `secondary_scene` if not provided.
 
     returns:
         None
@@ -394,13 +394,13 @@ def make_parameter_file(
     SPACECRAFT_HEIGHT = 693000.0
     EARTH_RADIUS = 6337286.638938101
 
-    parser = etree.XMLParser(encoding='utf-8', recover=True)
     if 'BURST' in reference_scene:
         ref_tag = reference_scene[-10:-6]
         sec_tag = secondary_scene[-10:-6]
     else:
         ref_tag = reference_scene[-4::]
         sec_tag = secondary_scene[-4::]
+    
     if reference_safe is None:
         reference_safe = [file for file in os.listdir('.') if file.endswith(f'{ref_tag}.SAFE')][0]
         secondary_safe = [file for file in os.listdir('.') if file.endswith(f'{sec_tag}.SAFE')][0]
@@ -410,6 +410,7 @@ def make_parameter_file(
     ref_annotation_path = f'{reference_safe}/annotation/'
     ref_annotation = [file for file in os.listdir(ref_annotation_path) if os.path.isfile(ref_annotation_path + file)][0]
 
+    parser = etree.XMLParser(encoding='utf-8', recover=True)
     ref_manifest_xml = etree.parse(f'{reference_safe}/manifest.safe', parser)
     sec_manifest_xml = etree.parse(f'{secondary_safe}/manifest.safe', parser)
     ref_annotation_xml = etree.parse(f'{ref_annotation_path}{ref_annotation}', parser)

--- a/src/hyp3_isce2/packaging.py
+++ b/src/hyp3_isce2/packaging.py
@@ -386,6 +386,7 @@ def make_parameter_file(
         dem_resolution: Resolution of the DEM
         reference_safe: The name of the reference SAFE file (only necessary for single-burst)
         secondary_safe: The name of the reference SAFE file (only necessary for single-burst)
+
     returns:
         None
     """

--- a/src/hyp3_isce2/packaging.py
+++ b/src/hyp3_isce2/packaging.py
@@ -370,6 +370,8 @@ def make_parameter_file(
     multilook_position: BurstPosition | None = None,
     dem_name: str = 'GLO_30',
     dem_resolution: int = 30,
+    reference_safe: str | None = None,
+    secondary_safe: str | None = None,
 ) -> None:
     """Create a parameter file for the output product
 
@@ -397,8 +399,10 @@ def make_parameter_file(
     else:
         ref_tag = reference_scene[-4::]
         sec_tag = secondary_scene[-4::]
-    reference_safe = [file for file in os.listdir('.') if file.endswith(f'{ref_tag}.SAFE')][0]
-    secondary_safe = [file for file in os.listdir('.') if file.endswith(f'{sec_tag}.SAFE')][0]
+        reference_safe = [file for file in os.listdir('.') if file.endswith(f'{ref_tag}.SAFE')][0]
+        secondary_safe = [file for file in os.listdir('.') if file.endswith(f'{sec_tag}.SAFE')][0]
+
+    assert reference_safe and secondary_safe
 
     ref_annotation_path = f'{reference_safe}/annotation/'
     ref_annotation = [file for file in os.listdir(ref_annotation_path) if os.path.isfile(ref_annotation_path + file)][0]

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -9,7 +9,6 @@ import asf_search
 import numpy as np
 import pytest
 from lxml import etree
-from shapely import geometry
 
 from hyp3_isce2 import burst, utils
 
@@ -78,62 +77,6 @@ def test_spoof_safe(tmp_path, mocker, pattern):
     ref_burst = burst.BurstMetadata(load_metadata('reference_descending.xml'), REF_DESC)
     burst.spoof_safe(ref_burst, mock_tiff, tmp_path)
     assert len(list(tmp_path.glob(pattern))) == 1
-
-
-@pytest.mark.parametrize('orbit', ('ascending', 'descending'))
-def test_get_region_of_interest(tmp_path, orbit):
-    """Test that the region of interest is correctly calculated for a given burst pair.
-    Specifically, the region of interest we create should intersect the bursts used to create it,
-    but not the bursts before or after it. This is difficult due to to the high degree of overlap between bursts.
-
-    This diagram shows the burst layout for a descending orbit (the 0 indicates the region of interest):
-          +---------------+
-          |               |
-       0--+------------+  |
-       |  |            |  |
-    +--+--+---------+--+--+
-    |  |            |  |
-    |  +------------+--+
-    |               |
-    +---------------+
-
-    And for an ascending orbit:
-    +--------------+
-    |              |
-    |  +------------+--0
-    |  |            |  |
-    +--+--+---------+--+--+
-       |  |            |  |
-       +--+------------+  |
-          |               |
-          +---------------+
-    """
-    options = {'descending': [REF_DESC, SEC_DESC], 'ascending': [REF_ASC, SEC_ASC]}
-
-    params = options[orbit]
-
-    for param, name in zip(params, ('reference', 'secondary')):
-        mock_tiff = tmp_path / 'test.tiff'
-        mock_tiff.touch()
-        burst_metadata = burst.BurstMetadata(load_metadata(f'{name}_{orbit}.xml'), param)
-        burst.spoof_safe(burst_metadata, mock_tiff, tmp_path)
-
-    sec_bbox = burst.get_isce2_burst_bbox(params[1], tmp_path)
-
-    granule = params[0].granule
-    burst_number = params[0].burst_number
-    swath = params[0].swath
-    pol = params[0].polarization
-    ref_bbox_pre = burst.get_isce2_burst_bbox(burst.BurstParams(granule, swath, pol, burst_number - 1), tmp_path)
-    ref_bbox_on = burst.get_isce2_burst_bbox(burst.BurstParams(granule, swath, pol, burst_number), tmp_path)
-    ref_bbox_post = burst.get_isce2_burst_bbox(burst.BurstParams(granule, swath, pol, burst_number + 1), tmp_path)
-
-    asc = orbit == 'ascending'
-    roi = geometry.box(*burst.get_region_of_interest(ref_bbox_on, sec_bbox, asc))
-
-    assert not roi.intersects(ref_bbox_pre)
-    assert roi.intersects(ref_bbox_on)
-    assert not roi.intersects(ref_bbox_post)
 
 
 def mock_asf_search_results(


### PR DESCRIPTION
This PR addresses #165. Setting the ISCE2 ROI to the corner of a burst will not always lead to a single-burst being subsetted by ISCE2. This happens regardless of the choice of corner. Using `burst2safe` avoids this problem by creating a safe file with only the desired burst in it.

Locally tested to verify that the processing is working.

TODO:
- [x] Remove functions that are no longer used
- [x] Address mypy errors
- [x] Fix the unit tests
- [x] Make sure that the `merge_tops_burst` workflow still functions correctly