### PR TITLE
Remove Unused Functions after the Switch to Burst2Safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.2.6
+## 2.2.0
 
 ### Changed
 - The `insar_tops_single_burst` workflow now uses [burst2safe](https://github.com/ASFHyP3/burst2safe) to eliminate the use of a region of interest with single-burst jobs, which was causing a [bug where multiple vrts would be cropped by ISCE2](https://github.com/ASFHyP3/hyp3-isce2/issues/165).

--- a/src/hyp3_isce2/etc/download_example.py
+++ b/src/hyp3_isce2/etc/download_example.py
@@ -6,7 +6,7 @@ hyp3_isce2.burst module.
 Example 1: Downloading metadata for a pair of ascending/descending bursts
             (these are the metadata files used in the test suite.)
 
-Example 2: Downloading a pair of ascending/descending bursts and spoofing a SAFE
+Example 2: Downloading a pair of bursts as spoofed SAFEs
 """
 
 from burst2safe import burst2safe

--- a/src/hyp3_isce2/etc/download_example.py
+++ b/src/hyp3_isce2/etc/download_example.py
@@ -56,4 +56,5 @@ with get_asf_session() as session:
 ref = 'S1_136231_IW2_20200604T022312_VV_7C85-BURST'
 sec = 'S1_136231_IW2_20200616T022313_VV_5D11-BURST'
 
-burst2safe.burst2safe([ref, sec], polarizations=['VV'], all_anns=True)
+burst2safe.burst2safe([ref])
+burst2safe.burst2safe([sec])

--- a/src/hyp3_isce2/etc/download_example.py
+++ b/src/hyp3_isce2/etc/download_example.py
@@ -9,9 +9,10 @@ Example 1: Downloading metadata for a pair of ascending/descending bursts
 Example 2: Downloading a pair of ascending/descending bursts and spoofing a SAFE
 """
 
+from burst2safe import burst2safe
+
 from hyp3_isce2.burst import (
     BurstParams,
-    download_bursts,
     download_metadata,
     get_asf_session,
 )
@@ -51,5 +52,8 @@ with get_asf_session() as session:
     download_metadata(session, sec_desc, 'secondary_descending.xml')
 
 # Example 2
-# Download with SAFE spoofing
-download_bursts([ref_desc, sec_desc])
+# Download with the burst2safe package
+ref = 'S1_136231_IW2_20200604T022312_VV_7C85-BURST'
+sec = 'S1_136231_IW2_20200616T022313_VV_5D11-BURST'
+
+burst2safe.burst2safe([ref, sec], polarizations=['VV'], all_anns=True)

--- a/src/hyp3_isce2/metadata/templates/insar_burst/insar_burst_readme.md.txt.j2
+++ b/src/hyp3_isce2/metadata/templates/insar_burst/insar_burst_readme.md.txt.j2
@@ -100,11 +100,11 @@ The basic steps in Sentinel-1 Burst InSAR processing are as follows:
 ----------------
 The detailed process, including the calls to ISCE2 software, is as follows:
 
-The prepare-processing and InSAR processing are combined in the insar_tps_burst function.
+The prepare-processing and InSAR processing are combined in the insar_tops_burst function.
 
 ## Pre-processing ##
- - download_bursts: Download the bursts according to reference and secondary parameters and re-create a SAFE-style directory
- - get_region_of_interest: Calculate the intersection area
+ - burst2safe: Download reference and secondary SAFE files containing only the desired bursts
+ - get_isce2_burst_bbox: Get the burst bounding boxes for the DEM region of interest
  - download_dem_for_isce2 : Download the DEM file
  - download_aux_cal: Download: the aux cal file
  - downloadSentinelOrbitFile: Download the orbit file

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -39,12 +39,6 @@ SEC_ASC = burst.BurstParams(
 )
 
 
-def load_metadata(metadata):
-    metadata_path = Path(__file__).parent.absolute() / 'data' / metadata
-    xml = etree.parse(metadata_path).getroot()
-    return xml
-
-
 def make_test_image(output_path, array=None):
     parent = Path(output_path).parent
     if not parent.exists():

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
-import asf_search
 import numpy as np
 import pytest
 from lxml import etree
@@ -58,91 +57,6 @@ def make_test_image(output_path, array=None):
     array = array.astype(np.float32)
     img_obj = utils.create_image(output_path, array.shape[1], access_mode='write', action='create')
     utils.write_isce2_image_from_obj(img_obj, array)
-
-
-@pytest.mark.parametrize(
-    'pattern',
-    (
-        '*SAFE',
-        '*SAFE/annotation/*xml',
-        '*SAFE/annotation/calibration/calibration*xml',
-        '*SAFE/annotation/calibration/noise*xml',
-        '*SAFE/measurement/*tiff',
-    ),
-)
-def test_spoof_safe(tmp_path, mocker, pattern):
-    mock_tiff = tmp_path / 'test.tiff'
-    mock_tiff.touch()
-
-    ref_burst = burst.BurstMetadata(load_metadata('reference_descending.xml'), REF_DESC)
-    burst.spoof_safe(ref_burst, mock_tiff, tmp_path)
-    assert len(list(tmp_path.glob(pattern))) == 1
-
-
-def mock_asf_search_results(
-    slc_name: str, subswath: str, polarization: str, burst_index: int
-) -> asf_search.ASFSearchResults:
-    product = asf_search.ASFProduct()
-    product.umm = {'InputGranules': [slc_name]}
-    product.properties.update(
-        {
-            'burst': {'subswath': subswath, 'burstIndex': burst_index},
-            'polarization': polarization,
-        }
-    )
-    results = asf_search.ASFSearchResults([product])
-    results.searchComplete = True
-    return results
-
-
-def test_get_burst_params_08F8():
-    with patch.object(asf_search, 'search') as mock_search:
-        mock_search.return_value = mock_asf_search_results(
-            slc_name='S1A_IW_SLC__1SDV_20230526T190821_20230526T190847_048709_05DBA8_08F8-SLC',
-            subswath='IW3',
-            polarization='VV',
-            burst_index=8,
-        )
-        assert burst.get_burst_params('S1_346041_IW3_20230526T190843_VV_08F8-BURST') == burst.BurstParams(
-            granule='S1A_IW_SLC__1SDV_20230526T190821_20230526T190847_048709_05DBA8_08F8',
-            swath='IW3',
-            polarization='VV',
-            burst_number=8,
-        )
-        mock_search.assert_called_once_with(product_list=['S1_346041_IW3_20230526T190843_VV_08F8-BURST'])
-
-
-def test_get_burst_params_1B3B():
-    with patch.object(asf_search, 'search') as mock_search:
-        mock_search.return_value = mock_asf_search_results(
-            slc_name='S1A_EW_SLC__1SDH_20230526T143200_20230526T143303_048706_05DB92_1B3B-SLC',
-            subswath='EW5',
-            polarization='HH',
-            burst_index=19,
-        )
-        assert burst.get_burst_params('S1_308695_EW5_20230526T143259_HH_1B3B-BURST') == burst.BurstParams(
-            granule='S1A_EW_SLC__1SDH_20230526T143200_20230526T143303_048706_05DB92_1B3B',
-            swath='EW5',
-            polarization='HH',
-            burst_number=19,
-        )
-        mock_search.assert_called_with(product_list=['S1_308695_EW5_20230526T143259_HH_1B3B-BURST'])
-
-
-def test_get_burst_params_burst_does_not_exist():
-    with patch.object(asf_search, 'search') as mock_search:
-        mock_search.return_value = []
-        with pytest.raises(ValueError, match=r'.*failed to find.*'):
-            burst.get_burst_params('this burst does not exist')
-        mock_search.assert_called_once_with(product_list=['this burst does not exist'])
-
-
-def test_get_burst_params_multiple_results():
-    with patch.object(asf_search, 'search') as mock_search:
-        mock_search.return_value = ['foo', 'bar']
-        with pytest.raises(ValueError, match=r'.*found multiple results.*'):
-            burst.get_burst_params('there are multiple copies of this burst')
-        mock_search.assert_called_once_with(product_list=['there are multiple copies of this burst'])
 
 
 def test_num_swath_pol():

--- a/tests/test_burst.py
+++ b/tests/test_burst.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
-from lxml import etree
 
 from hyp3_isce2 import burst, utils
 


### PR DESCRIPTION
This PR addresses @forrestfwilliams feedback on #296:

* [x]  Update changelog and release number
* [x]  Update ruff settings to match other hyp3 repos and ensure test passes (@jtherrmann curious if you have any suggestions here)
* [x]  Remove unused `download_bursts` function, tests, and docs
* [x]  Remove unused `get_burst_params` function, tests, and docs (make sure to check conftest.py for unused fixtures)
* [x]  Update download_example.py
* [x]  Update product readme template