### PR TITLE
Fix issue for insar_tops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Burst validator now accepts reference and secondary lists in any order with respect to burst number, swath and polarization.
+- Throws UserWarning instead of ResourceWarning when using `granules` flag
 
 ### Fixed
 - Allows bursts in water with water mask fixing issue <https://github.com/ASFHyP3/hyp3-isce2/issues/211>.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Allows bursts in water with water mask fixing issue <https://github.com/ASFHyP3/hyp3-isce2/issues/211>.
+- Bug for `insar_tops` as it searched for `burst_01.int.vrt` even when it was not a common burst with the secondary scene
 
 ## [2.3.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - Burst validator now accepts reference and secondary lists in any order with respect to burst number, swath and polarization.
+- Pinned to `burst2safe>=1.4.5` to address https://github.com/ASFHyP3/burst2safe/issues/170.
 - Throws UserWarning instead of ResourceWarning when using `granules` flag
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.2]
-
-### Changed
-- Burst validator now accepts reference and secondary lists in any order with respect to burst number, swath and polarization.
-- Pinned to `burst2safe>=1.4.5` to address https://github.com/ASFHyP3/burst2safe/issues/170.
-- Throws UserWarning instead of ResourceWarning when using `granules` flag
-
-### Fixed
-- Allows bursts in water with water mask fixing issue <https://github.com/ASFHyP3/hyp3-isce2/issues/211>.
-- Bug for `insar_tops` as it searched for `burst_01.int.vrt` even when it was not a common burst with the secondary scene
-
 ## [2.3.1]
 
 ### Changed

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -289,7 +289,7 @@ def main():
     elif has_granules:
         warnings.warn(
             'The positional argument for granules is deprecated. Please use --reference and --secondary.',
-            DeprecationWarning,
+            UserWarning,
         )
         granules = [item for sublist in args.granules for item in sublist]
         if len(granules) != 2:

--- a/src/hyp3_isce2/packaging.py
+++ b/src/hyp3_isce2/packaging.py
@@ -161,18 +161,18 @@ def translate_outputs(
     if use_multilooked:
         suffix += '.multilooked'
 
-    rdr_datasets = [
-        ISCE2Dataset(
-            find_product(f'fine_interferogram/IW*/burst_{suffix}.int.vrt'),
-            'wrapped_phase_rdr',
-            [1],
-            gdalconst.GDT_CFloat32,
-        ),
-        ISCE2Dataset(find_product(f'geom_reference/IW*/lat_{suffix}.rdr.vrt'), 'lat_rdr', [1]),
-        ISCE2Dataset(find_product(f'geom_reference/IW*/lon_{suffix}.rdr.vrt'), 'lon_rdr', [1]),
-        ISCE2Dataset(find_product(f'geom_reference/IW*/los_{suffix}.rdr.vrt'), 'los_rdr', [1, 2]),
-    ]
     if include_radar:
+        rdr_datasets = [
+            ISCE2Dataset(
+                find_product(f'fine_interferogram/IW*/burst_{suffix}.int.vrt'),
+                'wrapped_phase_rdr',
+                [1],
+                gdalconst.GDT_CFloat32,
+            ),
+            ISCE2Dataset(find_product(f'geom_reference/IW*/lat_{suffix}.rdr.vrt'), 'lat_rdr', [1]),
+            ISCE2Dataset(find_product(f'geom_reference/IW*/lon_{suffix}.rdr.vrt'), 'lon_rdr', [1]),
+            ISCE2Dataset(find_product(f'geom_reference/IW*/los_{suffix}.rdr.vrt'), 'los_rdr', [1, 2]),
+        ]
         datasets += rdr_datasets
 
     for dataset in datasets:


### PR DESCRIPTION
This PR fixes a bug for `insar_tops` when the first burst in the reference scene is not a common burst with the secondary scene