### PR TITLE
Fix bug in insar_tops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3]
+
+### Changed
+- The `insar_tops` now does not look for the radar products in the first burst because sometimes this burst does not overlap with the secondary slc. 
+
 ## [2.3.2]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [2.3.3]
 
 ### Changed
-- The `insar_tops` now does not look for the radar products in the first burst because sometimes this burst does not overlap with the secondary slc. 
+- The `insar_tops` now does not look for the radar products in the first burst because sometimes this burst does not overlap with the secondary slc.
+
+### Fixed
+- Changed `DeprecationWarning` for `UserWarning` when using `granules` argument with the `insar_tops_burst` workflow. Fixes https://github.com/ASFHyP3/hyp3-isce2/issues/279
 
 ## [2.3.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [2.3.3]
 
 ### Changed
-- The `insar_tops` now does not look for the radar products in the first burst because sometimes this burst does not overlap with the secondary slc.
+- When called from `insar_tops`, `translate_outputs` no longer looks for radar products for the first burst as it might not overlap with the secondary SLC.
 
 ### Fixed
 - Changed `DeprecationWarning` for `UserWarning` when using `granules` argument with the `insar_tops_burst` workflow. Fixes https://github.com/ASFHyP3/hyp3-isce2/issues/279

--- a/src/hyp3_isce2/insar_tops_burst.py
+++ b/src/hyp3_isce2/insar_tops_burst.py
@@ -289,7 +289,7 @@ def main():
     elif has_granules:
         warnings.warn(
             'The positional argument for granules is deprecated. Please use --reference and --secondary.',
-            DeprecationWarning,
+            UserWarning,
         )
         granules = [item for sublist in args.granules for item in sublist]
         if len(granules) != 2:

--- a/src/hyp3_isce2/packaging.py
+++ b/src/hyp3_isce2/packaging.py
@@ -161,18 +161,18 @@ def translate_outputs(
     if use_multilooked:
         suffix += '.multilooked'
 
-    rdr_datasets = [
-        ISCE2Dataset(
-            find_product(f'fine_interferogram/IW*/burst_{suffix}.int.vrt'),
-            'wrapped_phase_rdr',
-            [1],
-            gdalconst.GDT_CFloat32,
-        ),
-        ISCE2Dataset(find_product(f'geom_reference/IW*/lat_{suffix}.rdr.vrt'), 'lat_rdr', [1]),
-        ISCE2Dataset(find_product(f'geom_reference/IW*/lon_{suffix}.rdr.vrt'), 'lon_rdr', [1]),
-        ISCE2Dataset(find_product(f'geom_reference/IW*/los_{suffix}.rdr.vrt'), 'los_rdr', [1, 2]),
-    ]
     if include_radar:
+        rdr_datasets = [
+            ISCE2Dataset(
+                find_product(f'fine_interferogram/IW*/burst_{suffix}.int.vrt'),
+                'wrapped_phase_rdr',
+                [1],
+                gdalconst.GDT_CFloat32,
+            ),
+            ISCE2Dataset(find_product(f'geom_reference/IW*/lat_{suffix}.rdr.vrt'), 'lat_rdr', [1]),
+            ISCE2Dataset(find_product(f'geom_reference/IW*/lon_{suffix}.rdr.vrt'), 'lon_rdr', [1]),
+            ISCE2Dataset(find_product(f'geom_reference/IW*/los_{suffix}.rdr.vrt'), 'los_rdr', [1, 2]),
+        ]
         datasets += rdr_datasets
 
     for dataset in datasets:


### PR DESCRIPTION
This PR fixes issue #279 and a bug in the packaging for `insar_tops` when the first burst in the reference scene is not a common burst in the secondary scene. This bug appears with the granules S1A_IW_SLC__1SDV_20230720T005434_20230720T005507_049500_05F3C5_CD3B, S1A_IW_SLC__1SDV_20230801T005439_20230801T005505_049675_05F92D_CEF9