### PR TITLE
resolve importlib.metadata deprecation warning

### DIFF
--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -46,10 +46,7 @@ def main():
             UserWarning,
         )
 
-    # NOTE: Cast to set because of: https://github.com/pypa/setuptools/issues/3649
-    # NOTE: Will need to update to `entry_points(group='hyp3', name=args.process)` when updating to python 3.10
-    eps = entry_points(group='hyp3')
-    (process_entry_point,) = {process for process in eps if process.name == args.process}
+    process_entry_point = list(entry_points(group='hyp3', name=args.process))[0]
 
     if args.omp_num_threads:
         os.environ['OMP_NUM_THREADS'] = str(args.omp_num_threads)

--- a/src/hyp3_isce2/__main__.py
+++ b/src/hyp3_isce2/__main__.py
@@ -48,7 +48,7 @@ def main():
 
     # NOTE: Cast to set because of: https://github.com/pypa/setuptools/issues/3649
     # NOTE: Will need to update to `entry_points(group='hyp3', name=args.process)` when updating to python 3.10
-    eps = entry_points()['hyp3']
+    eps = entry_points(group='hyp3')
     (process_entry_point,) = {process for process in eps if process.name == args.process}
 
     if args.omp_num_threads:


### PR DESCRIPTION
running `python -m hyp3_isce2 insar_tops_burst --help` currently generates this deprecation warning:

```
/home/asjohnston/src/hyp3-isce2/src/hyp3_isce2/__main__.py:51: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
  eps = entry_points()['hyp3']
```

See https://docs.python.org/3/library/importlib.metadata.html#entry-points , in particular:

> Changed in version 3.12: The “selectable” entry points were introduced in importlib_metadata 3.6 and Python 3.10. Prior to those changes, entry_points accepted no parameters and always returned a dictionary of entry points, keyed by group. With importlib_metadata 5.0 and Python 3.12, entry_points always returns an EntryPoints object. See [backports.entry_points_selectable](https://pypi.org/project/backports.entry_points_selectable/) for compatibility options.