### PR TITLE
Revert "use tmp path in test"

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,11 +61,12 @@ def test_make_browse_image():
     os.remove(output_png)
 
 
-def test_make_browse_image_geotiff_all_nodata(tmp_path):
+def test_make_browse_image_geotiff_all_nodata():
     input_empty = 'tests/data/test_empty.tif'
-    output_png = str(tmp_path / 'output.png')
+    output_png = 'tests/data/test_browse_empty2.png'
     utils.make_browse_image(input_empty, output_png)
     assert open(output_png, 'rb').read() == open('tests/data/test_browse_empty.png', 'rb').read()
+    os.remove(output_png)
 
 
 def check_correctness_of_resample(mask, lat, lon, geotransform, data_type, outshape):


### PR DESCRIPTION
Reverts ASFHyP3/hyp3-isce2#331

I didn't realize this test was adapted from `test_make_browse_image`, and that the advantage of not using a tmp path is being able to very easily inspect the bad output image if the test fails (but it gets removed if the test succeeds).