### PR TITLE
drop merged/topophase.cor from list of products to geocode

### DIFF
--- a/src/hyp3_isce2/topsapp.py
+++ b/src/hyp3_isce2/topsapp.py
@@ -37,7 +37,6 @@ TOPSAPP_GEOCODE_LIST = [
     'merged/filt_topophase.unw',
     'merged/los.rdr',
     'merged/filt_topophase.flat',
-    'merged/topophase.cor',
     'merged/filt_topophase.unw.conncomp',
 ]
 


### PR DESCRIPTION
`TOPSAPP_GEOCODE_LIST` tells isce2 which products to convert from radar coordinates to geographic coordinates at the end of the processing run. We only need to geocode objects we're packaging for the user or that we're using in post-processing.

`topophase.cor` has no other mentions in the repository and `insar_tops_multi_burst --reference S1_093118_IW3_20250730T172125_VV_6465-BURST --secondary S1_093118_IW3_20250811T172125_VV_E882-BURST --apply-water-mask True ` runs fine without including it in the geocode list.

I confirmed the other five file _are_ referenced in packaging.translate_outputs().