### PR TITLE
Add parameter to send output file to external bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.2]
+
+### Added
+- Added a new `--publish-bucket` CLI parameter to `insar_tops_multi_burst` to upload the output file to an external bucket.
+
 ## [4.1.1]
 
 ### Fixed

--- a/src/hyp3_isce2/insar_tops_multi_burst.py
+++ b/src/hyp3_isce2/insar_tops_multi_burst.py
@@ -15,7 +15,7 @@ from hyp3_isce2 import packaging
 from hyp3_isce2.burst import validate_bursts
 from hyp3_isce2.insar_tops import insar_tops
 from hyp3_isce2.logger import configure_root_logger
-from hyp3_isce2.utils import get_volcsarvatory_prefix, make_browse_image
+from hyp3_isce2.utils import get_multiburst_prefix, make_browse_image
 
 
 gdal.UseExceptions()
@@ -188,5 +188,5 @@ def main():
         packaging.upload_product_to_s3(product_dir, output_zip, args.bucket, args.bucket_prefix)
 
     if args.publish_bucket:
-        prefix, s3_name = get_volcsarvatory_prefix(output_zip)
+        prefix, s3_name = get_multiburst_prefix(output_zip)
         packaging.upload_file_to_s3_with_publish_access_keys(output_zip, args.publish_bucket, prefix, s3_name)

--- a/src/hyp3_isce2/insar_tops_multi_burst.py
+++ b/src/hyp3_isce2/insar_tops_multi_burst.py
@@ -15,7 +15,7 @@ from hyp3_isce2 import packaging
 from hyp3_isce2.burst import validate_bursts
 from hyp3_isce2.insar_tops import insar_tops
 from hyp3_isce2.logger import configure_root_logger
-from hyp3_isce2.utils import make_browse_image
+from hyp3_isce2.utils import get_volcsarvatory_prefix, make_browse_image
 
 
 gdal.UseExceptions()
@@ -154,6 +154,13 @@ def main():
     )
     parser.add_argument('--bucket', help='AWS S3 bucket HyP3 for upload the final product(s)')
     parser.add_argument('--bucket-prefix', default='', help='Add a bucket prefix to product(s)')
+    parser.add_argument(
+        '--publish-bucket',
+        type=str,
+        default=None,
+        help='Additionally, publish products to this bucket. Necessary credentials must be provided '
+        'via the `PUBLISH_ACCESS_KEY_ID` and `PUBLISH_SECRET_ACCESS_KEY` environment variables.',
+    )
 
     args = parser.parse_args()
 
@@ -179,3 +186,7 @@ def main():
 
     if args.bucket:
         packaging.upload_product_to_s3(product_dir, output_zip, args.bucket, args.bucket_prefix)
+
+    if args.publish_bucket:
+        prefix, s3_name = get_volcsarvatory_prefix(output_zip)
+        packaging.upload_file_to_s3_with_publish_access_keys(output_zip, args.publish_bucket, prefix, s3_name)

--- a/src/hyp3_isce2/utils.py
+++ b/src/hyp3_isce2/utils.py
@@ -395,7 +395,7 @@ def get_projection(srs_wkt) -> str:
     return srs.GetAttrValue('projcs')
 
 
-def get_volcsarvatory_prefix(fpath: Path) -> tuple:
+def get_multiburst_prefix(fpath: Path) -> tuple:
     # files will go to the burst set folder
     burst_set = str(fpath.name).replace('-', '_')
     keep = [burst_set.split('_')[i] for i in [1, 2, 3, 4, 9]]

--- a/src/hyp3_isce2/utils.py
+++ b/src/hyp3_isce2/utils.py
@@ -393,3 +393,15 @@ def get_projection(srs_wkt) -> str:
     srs = osr.SpatialReference()
     srs.ImportFromWkt(srs_wkt)
     return srs.GetAttrValue('projcs')
+
+
+def get_volcsarvatory_prefix(fpath: Path) -> tuple:
+    # files will go to the burst set folder
+    burst_set = str(fpath.name).replace('-', '_')
+    keep = [burst_set.split('_')[i] for i in [1, 2, 3, 4, 9]]
+    subkeep = str(fpath.name).split('_')[0:-1] + ['0000']
+    dir_name = '_'.join(keep)
+    s3_name = '_'.join(subkeep) + '.zip'
+    prefix = f'multiburst_products/{dir_name}'
+
+    return prefix, s3_name

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,4 +1,7 @@
+from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from hyp3_isce2 import packaging
 
@@ -213,3 +216,19 @@ def test_make_parameter_file(test_data_dir, tmp_path):
             'Water mask: yes\n',
         ]
     )
+
+
+def test_upload_file_to_s3_credentials_missing(tmp_path, monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv('PUBLISH_ACCESS_KEY_ID', raising=False)
+        m.setenv('PUBLISH_SECRET_ACCESS_KEY', 'publish_access_key_secret')
+        msg = 'Please provide.*'
+        with pytest.raises(ValueError, match=msg):
+            packaging.upload_file_to_s3_with_publish_access_keys(Path('file.zip'), 'myBucket')
+
+    with monkeypatch.context() as m:
+        m.setenv('PUBLISH_ACCESS_KEY_ID', 'publish_access_key_id')
+        m.delenv('PUBLISH_SECRET_ACCESS_KEY', raising=False)
+        msg = 'Please provide.*'
+        with pytest.raises(ValueError, match=msg):
+            packaging.upload_file_to_s3_with_publish_access_keys(Path('file.zip'), 'myBucket')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -309,9 +309,9 @@ def test_image_math(tmp_path):
     assert np.array_equal(array1 + array2, arrayout)
 
 
-def test_get_opendata_prefix():
+def test_get_multiburst_prefix():
     file = Path('tests/data/S1_044_000000s1n00-000000s2n00-093117s3n03_IW_20180309_20190421_VV_INT80_2746.zip')
     assert (
-        '/'.join([*utils.get_volcsarvatory_prefix(file)])
+        '/'.join([*utils.get_multiburst_prefix(file)])
         == 'multiburst_products/044_000000s1n00_000000s2n00_093117s3n03_INT80/S1_044_000000s1n00-000000s2n00-093117s3n03_IW_20180309_20190421_VV_INT80_0000.zip'
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -307,3 +307,11 @@ def test_image_math(tmp_path):
     utils.image_math(in_path1, in_path2, out_path, 'a + b')
     image_obj_out, arrayout = utils.load_isce2_image(out_path)
     assert np.array_equal(array1 + array2, arrayout)
+
+
+def test_get_opendata_prefix():
+    file = Path('tests/data/S1_044_000000s1n00-000000s2n00-093117s3n03_IW_20180309_20190421_VV_INT80_2746.zip')
+    assert (
+        '/'.join([*utils.get_volcsarvatory_prefix(file)])
+        == 'multiburst_products/044_000000s1n00_000000s2n00_093117s3n03_INT80/S1_044_000000s1n00-000000s2n00-093117s3n03_IW_20180309_20190421_VV_INT80_0000.zip'
+    )


### PR DESCRIPTION
This PR adds a new parameter `--publish-bucket` to send the output file to an external bucket. This is very similar to the option included in `hyp3-autorift`.

Eventually, if other plugins need this option we could to make a PR to `hyp3-lib`.